### PR TITLE
fix(scroll): support show/hide cursor and fix vim scrolling behaviour

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -269,7 +269,7 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: Opt) {
             send_screen_instructions.send(ScreenInstruction::ScrollDown).unwrap();
         } else if buffer[0] == 24 { // ctrl-x
             send_screen_instructions.send(ScreenInstruction::CloseFocusedPane).unwrap();
-        } else if buffer[0] == 6 { // ctrl-f
+        } else if buffer[0] == 5 { // ctrl-e
             send_screen_instructions.send(ScreenInstruction::ToggleActiveTerminalFullscreen).unwrap();
         } else {
             // println!("\r buffer {:?}   ", buffer[0]);

--- a/src/tests/integration/basic.rs
+++ b/src/tests/integration/basic.rs
@@ -170,7 +170,7 @@ pub fn toggle_focused_pane_fullscreen () {
     // split-largest_terminal * 3, toggle-fullscreen * 2, ctrl-p, toggle-fullscreen * 2, ctrl-p, toggle-fullscreen * 2, ctrl-p, toggle-fullscreen * 2 and quit
     // (ctrl-z + ctrl-z + ctrl-z + ctrl-z + ctrl-f, ctrl-f, ctrl-p, ctrl-f, ctrl-f, ctrl-p, ctrl-f,
     // ctrl-f, ctrl-p, ctrl-f, ctrl-f, ctrl-q)
-    fake_input_output.add_terminal_input(&[26, 26, 26, 6, 6, 16, 6, 6, 16, 6, 6, 16, 6, 6, 17]);
+    fake_input_output.add_terminal_input(&[26, 26, 26, 5, 5, 16, 5, 5, 16, 5, 5, 16, 5, 5, 17]);
     let mut opts = Opt::default();
     opts.max_panes = Some(4);
     start(Box::new(fake_input_output.clone()), opts);

--- a/src/tests/integration/snapshots/mosaic__tests__integration__compatibility__run_bandwhich_from_fish_shell-2.snap
+++ b/src/tests/integration/snapshots/mosaic__tests__integration__compatibility__run_bandwhich_from_fish_shell-2.snap
@@ -29,4 +29,4 @@ expression: snapshot
 │                                                                                                                  │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                       
-Bye from Mosaic!█                                                                                                   
+Bye from Mosaic!                                                                                                    

--- a/src/tests/integration/snapshots/mosaic__tests__integration__compatibility__run_bandwhich_from_fish_shell.snap
+++ b/src/tests/integration/snapshots/mosaic__tests__integration__compatibility__run_bandwhich_from_fish_shell.snap
@@ -6,7 +6,7 @@ expression: snapshot
 ┌Utilization by process name───────────────────────────────────────────────────────────────────────────────────────┐
 │Process                                              Connections              Up / Down                           │
 │                                                                                                                  │
-│firefox                                              3                        46Bps / 5█Bps                       │
+│firefox                                              3                        46Bps / 57Bps                       │
 │                                                                                                                  │
 │                                                                                                                  │
 │                                                                                                                  │

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -14,15 +14,17 @@ pub fn get_output_frame_snapshots(output_frames: &[Vec<u8>], win_size: &Winsize)
             vte_parser.advance(&mut terminal_output, *byte);
         }
         let output_lines = terminal_output.read_buffer_as_lines();
-        let (cursor_x, cursor_y) = terminal_output.cursor_coordinates();
+        let cursor_coordinates = terminal_output.cursor_coordinates();
         let mut snapshot = String::new();
         for (line_index, line) in output_lines.iter().enumerate() {
             for (character_index, terminal_character) in line.iter().enumerate() {
-                if line_index == cursor_y && character_index == cursor_x {
-                    snapshot.push('█');
-                } else {
-                    snapshot.push(terminal_character.character);
+                if let Some((cursor_x, cursor_y)) = cursor_coordinates {
+                    if line_index == cursor_y && character_index == cursor_x {
+                        snapshot.push('█');
+                        continue;
+                    }
                 }
+                snapshot.push(terminal_character.character);
             }
             if line_index != output_lines.len() - 1 {
                 snapshot.push('\n');


### PR DESCRIPTION
I originally set out to fix a bug where if you'd expand a vim pane to fullscreen, the pane would only expand vertically and not horizontally (the same amount of lines would stay on screen).

Turns out this was caused (surprisingly enough) because we weren't properly reacting to the cursor show/hide CSI instructions.

Why? Vim uses the terminal scrolling region (as described here: https://vt100.net/docs/vt102-ug/chapter5.html). Apparently, when the cursor is hidden, the scroll region should be ignored (because the cursor is not between the first and last line of the scroll region - it is nowhere). Now it works, AND we support hiding the cursor.