### PR TITLE
fix(compatibility): better stdin reading to fix various issues

### DIFF
--- a/src/os_input_output.rs
+++ b/src/os_input_output.rs
@@ -24,7 +24,6 @@ fn into_raw_mode(pid: RawFd) {
         Ok(_) => {},
         Err(e) => panic!("error {:?}", e)
     };
-
 }
 
 pub fn get_terminal_size_using_fd(fd: RawFd) -> Winsize {
@@ -94,7 +93,8 @@ fn handle_command_exit(mut child: Child) {
 
 fn spawn_terminal (file_to_open: Option<PathBuf>) -> (RawFd, RawFd) {
     let (pid_primary, pid_secondary): (RawFd, RawFd) = {
-        match forkpty(None, None) {
+        let current_termios = tcgetattr(0).unwrap();
+        match forkpty(None, Some(&current_termios)) {
             Ok(fork_pty_res) => {
                 let pid_primary = fork_pty_res.master;
                 let pid_secondary = match fork_pty_res.fork_result {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -62,7 +62,7 @@ pub enum ScreenInstruction {
     NewPane(RawFd),
     HorizontalSplit(RawFd),
     VerticalSplit(RawFd),
-    WriteCharacter(u8),
+    WriteCharacter([u8; 10]),
     ResizeLeft,
     ResizeRight,
     ResizeDown,
@@ -257,10 +257,9 @@ impl Screen {
         let terminal_output = self.terminals.get_mut(&pid).unwrap();
         terminal_output.handle_event(event);
     }
-    pub fn write_to_active_terminal(&mut self, byte: u8) {
+    pub fn write_to_active_terminal(&mut self, mut bytes: [u8; 10]) {
         if let Some(active_terminal_id) = &self.get_active_terminal_id() {
-            let mut buffer = [byte];
-            self.os_api.write_to_tty_stdin(*active_terminal_id, &mut buffer).expect("failed to write to terminal");
+            self.os_api.write_to_tty_stdin(*active_terminal_id, &mut bytes).expect("failed to write to terminal");
             self.os_api.tcdrain(*active_terminal_id).expect("failed to drain terminal");
         }
     }


### PR DESCRIPTION
### What does this fix?
* Arrow keys now work as expected.
* Ctrl-c now works as expected.
* ESC now works as expected
(maybe some other stuff that I wasn't aware of should also start working)

### What was changed?
Instead of reading one byte from stdin, we now read 10. It's a little arbitrary, but I guess should work for most (all?) cases. A better way to go about it would be to detect how many bytes we read and match against that, but it's really not critical for the moment.
