### PR TITLE
fix(compatibility): do not interpret esc as scroll-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Some temporary controls (these will be changed to something more convenient when
   * ctrl-h - resize focused pane left
   * ctrl-l - resize focused pane right
   * ctrl-p - move focus to next pane
-  * ctrl-[ - scroll up in focused pane
-  * ctrl-] - scroll down in focused pane
+  * ctrl-PgUp - scroll up in focused pane
+  * ctrl-PgDown - scroll down in focused pane
   * ctrl-x - close focused pane
   * ctrl-q - quit Mosaic
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,10 +276,10 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: Opt) {
                 send_pty_instructions.send(PtyInstruction::Quit).unwrap();
                 break;
             },
-            [27, 0, 0, 0, 0, 0, 0, 0, 0, 0] => { // ctrl-[
+            [27, 91, 53, 94, 0, 0, 0, 0, 0, 0] => { // ctrl-PgUp
                 send_screen_instructions.send(ScreenInstruction::ScrollUp).unwrap();
             },
-            [29, 0, 0, 0, 0, 0, 0, 0, 0, 0] => { // ctrl-]
+            [27, 91, 54, 94, 0, 0, 0, 0, 0, 0] => { // ctrl-PgDown
                 send_screen_instructions.send(ScreenInstruction::ScrollDown).unwrap();
             },
             [24, 0, 0, 0, 0, 0, 0, 0, 0, 0] => { // ctrl-x

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -257,9 +257,20 @@ impl Screen {
         let terminal_output = self.terminals.get_mut(&pid).unwrap();
         terminal_output.handle_event(event);
     }
-    pub fn write_to_active_terminal(&mut self, mut bytes: [u8; 10]) {
+    pub fn write_to_active_terminal(&mut self, bytes: [u8; 10]) {
         if let Some(active_terminal_id) = &self.get_active_terminal_id() {
-            self.os_api.write_to_tty_stdin(*active_terminal_id, &mut bytes).expect("failed to write to terminal");
+            // this is a bit of a hack and is done in order not to send trailing
+            // zeros to the terminal (because they mess things up)
+            // TODO: fix this by only sending around the exact bytes read from stdin
+            let mut trimmed_bytes = vec![];
+            for byte in bytes.iter() {
+                if *byte == 0 {
+                    break;
+                } else {
+                    trimmed_bytes.push(*byte);
+                }
+            }
+            self.os_api.write_to_tty_stdin(*active_terminal_id, &mut trimmed_bytes).expect("failed to write to terminal");
             self.os_api.tcdrain(*active_terminal_id).expect("failed to drain terminal");
         }
     }

--- a/src/tests/integration/basic.rs
+++ b/src/tests/integration/basic.rs
@@ -4,6 +4,19 @@ use ::insta::assert_snapshot;
 use crate::{start, Opt};
 use crate::tests::fakes::{FakeInputOutput};
 use crate::tests::utils::get_output_frame_snapshots;
+use crate::tests::utils::commands::{
+    SPLIT_HORIZONTALLY,
+    SPLIT_VERTICALLY,
+    RESIZE_UP,
+    MOVE_FOCUS,
+    RESIZE_LEFT,
+    RESIZE_RIGHT,
+    SPAWN_TERMINAL,
+    QUIT,
+    SCROLL_UP,
+    SCROLL_DOWN,
+    TOGGLE_ACTIVE_TERMINAL_FULLSCREEN,
+};
 
 fn get_fake_os_input (fake_win_size: &Winsize) -> FakeInputOutput {
     FakeInputOutput::new(fake_win_size.clone())
@@ -11,14 +24,14 @@ fn get_fake_os_input (fake_win_size: &Winsize) -> FakeInputOutput {
 
 #[test]
 pub fn starts_with_one_terminal () {
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[17]); // quit (ctrl-q)
+    fake_input_output.add_terminal_input(&[QUIT]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -29,14 +42,17 @@ pub fn starts_with_one_terminal () {
 
 #[test]
 pub fn split_terminals_vertically() {
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[14, 17]); // split-vertically and quit (ctrl-n + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -47,14 +63,17 @@ pub fn split_terminals_vertically() {
 
 #[test]
 pub fn split_terminals_horizontally() {
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[2, 17]); // split-horizontally and quit (ctrl-b + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -66,14 +85,19 @@ pub fn split_terminals_horizontally() {
 #[test]
 pub fn split_largest_terminal () {
     // this finds the largest pane and splits along its longest edge (vertically or horizontally)
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[26, 26, 26, 17]); // split-largest_terminal * 3 and quit (ctrl-z + ctrl-z + ctrl-z + ctrl-z + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPAWN_TERMINAL,
+        SPAWN_TERMINAL,
+        SPAWN_TERMINAL,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -99,7 +123,7 @@ pub fn resize_right_and_up_on_the_same_axis() {
     // │█████│     │                   │█████│     │
     // └─────┴─────┘                   └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 40,
         ws_xpixel: 0,
@@ -107,9 +131,18 @@ pub fn resize_right_and_up_on_the_same_axis() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b + ctrl-n + ctrl-p + ctrl-n + ctrl-p * 2 + ctrl-l + ctrl-h + ctrl-k + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 14, 16, 14, 16, 16, 12, 8, 11, 17]);
-
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_RIGHT,
+        RESIZE_LEFT,
+        RESIZE_UP,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -120,14 +153,22 @@ pub fn resize_right_and_up_on_the_same_axis() {
 
 #[test]
 pub fn scrolling_inside_a_pane() {
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[2, 14, 27, 27, 29, 29, 17]); // split-horizontally, split-vertically, scroll up twice, scroll down twice and quit (ctrl-b + ctrl+[ * 2 + ctrl+] * 2, ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        SCROLL_UP,
+        SCROLL_UP,
+        SCROLL_DOWN,
+        SCROLL_DOWN,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -140,14 +181,20 @@ pub fn scrolling_inside_a_pane() {
 pub fn max_panes () {
     // with the --max-panes option, we only allow a certain amount of panes on screen
     // simultaneously, new panes beyond this limit will close older panes on screen
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[26, 26, 26, 26, 17]); // split-largest_terminal * 4 and quit (ctrl-z + ctrl-z + ctrl-z + ctrl-z + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPAWN_TERMINAL,
+        SPAWN_TERMINAL,
+        SPAWN_TERMINAL,
+        SPAWN_TERMINAL,
+        QUIT
+    ]);
     let mut opts = Opt::default();
     opts.max_panes = Some(4);
     start(Box::new(fake_input_output.clone()), opts);
@@ -160,17 +207,30 @@ pub fn max_panes () {
 
 #[test]
 pub fn toggle_focused_pane_fullscreen () {
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-largest_terminal * 3, toggle-fullscreen * 2, ctrl-p, toggle-fullscreen * 2, ctrl-p, toggle-fullscreen * 2, ctrl-p, toggle-fullscreen * 2 and quit
-    // (ctrl-z + ctrl-z + ctrl-z + ctrl-z + ctrl-f, ctrl-f, ctrl-p, ctrl-f, ctrl-f, ctrl-p, ctrl-f,
-    // ctrl-f, ctrl-p, ctrl-f, ctrl-f, ctrl-q)
-    fake_input_output.add_terminal_input(&[26, 26, 26, 5, 5, 16, 5, 5, 16, 5, 5, 16, 5, 5, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPAWN_TERMINAL,
+        SPAWN_TERMINAL,
+        SPAWN_TERMINAL,
+        TOGGLE_ACTIVE_TERMINAL_FULLSCREEN,
+        TOGGLE_ACTIVE_TERMINAL_FULLSCREEN,
+        MOVE_FOCUS,
+        TOGGLE_ACTIVE_TERMINAL_FULLSCREEN,
+        TOGGLE_ACTIVE_TERMINAL_FULLSCREEN,
+        MOVE_FOCUS,
+        TOGGLE_ACTIVE_TERMINAL_FULLSCREEN,
+        TOGGLE_ACTIVE_TERMINAL_FULLSCREEN,
+        MOVE_FOCUS,
+        TOGGLE_ACTIVE_TERMINAL_FULLSCREEN,
+        TOGGLE_ACTIVE_TERMINAL_FULLSCREEN,
+        QUIT
+    ]);
     let mut opts = Opt::default();
     opts.max_panes = Some(4);
     start(Box::new(fake_input_output.clone()), opts);

--- a/src/tests/integration/close_pane.rs
+++ b/src/tests/integration/close_pane.rs
@@ -5,6 +5,17 @@ use crate::{start, Opt};
 use crate::tests::fakes::{FakeInputOutput};
 use crate::tests::utils::get_output_frame_snapshots;
 
+use crate::tests::utils::commands::{
+    SPLIT_HORIZONTALLY,
+    SPLIT_VERTICALLY,
+    RESIZE_DOWN,
+    RESIZE_UP,
+    MOVE_FOCUS,
+    RESIZE_LEFT,
+    QUIT,
+    CLOSE_FOCUSED_PANE,
+};
+
 fn get_fake_os_input (fake_win_size: &Winsize) -> FakeInputOutput {
     FakeInputOutput::new(fake_win_size.clone())
 }
@@ -26,7 +37,11 @@ pub fn close_pane_with_another_pane_above_it() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[2, 24, 17]); // split-horizontally, close focused pane and quit (ctrl-b + ctrl-x + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -53,7 +68,12 @@ pub fn close_pane_with_another_pane_below_it() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[2, 16, 24, 17]); // split-horizontally, change-focus, close focused pane and quit (ctrl-b + ctrl-p + ctrl-x + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -78,7 +98,11 @@ pub fn close_pane_with_another_pane_to_the_left() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[14, 24, 17]); // split-vertically, close focused pane and quit (ctrl-n + ctrl-x + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -103,7 +127,12 @@ pub fn close_pane_with_another_pane_to_the_right() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[14, 16, 24, 17]); // split-vertically, change-focus, close focused pane and quit (ctrl-n + ctrl-p + ctrl-x + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -130,9 +159,15 @@ pub fn close_pane_with_multiple_panes_above_it() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-horizontally, change-focus, split-vertically, change-focus * 2, close focused pane and quit
-    // (ctrl-b + ctrl-p + ctrl-n + ctrl-p * 2 + ctrl-x + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 16, 14, 16, 16, 24, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -159,9 +194,13 @@ pub fn close_pane_with_multiple_panes_below_it() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-horizontally, split-vertically, change-focus, change-focus, close focused pane and quit
-    // (ctrl-b + ctrl-n + ctrl-p + ctrl-x + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 14, 16, 24, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -188,9 +227,15 @@ pub fn close_pane_with_multiple_panes_to_the_left() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-vertically, change-focus, split-horizontally, change-focus * 2, close focused pane and quit
-    // (ctrl-n + ctrl-p + ctrl-b + ctrl-p * 2 + ctrl-x + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 16, 2, 16, 16, 24, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -217,9 +262,13 @@ pub fn close_pane_with_multiple_panes_to_the_right() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-vertically, change-focus, split-horizontally, change-focus * 2, close focused pane and quit
-    // (ctrl-n + ctrl-p + ctrl-b + ctrl-p * 2 + ctrl-x + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 24, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -246,12 +295,27 @@ pub fn close_pane_with_multiple_panes_above_it_away_from_screen_edges() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-horizontally, split-vertically * 2, change-focus, split-vertically * 2, resize-up,
-    // change-focus, resize-up, close focuse * 4, split-vertically, change-focus * 3, close-focused-pane and quit
-    //
-    // (ctrl-b + ctrl-n + ctrl-n + ctrl-p + ctrl-n + ctrl-n + ctrl-k + ctrl-p + ctrl-k + ctrl-p * 4
-    // + ctrl-n + ctrl-p * 3 + ctrl-x + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 14, 14, 16, 14, 14, 11, 16, 11, 16, 16, 16, 16, 14, 16, 16, 16, 24, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        RESIZE_UP,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -278,12 +342,27 @@ pub fn close_pane_with_multiple_panes_below_it_away_from_screen_edges() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-horizontally, split-vertically * 2, change-focus, split-vertically * 2,
-    // resize-down, change-focus, resize-down, change-focus * 2, split-vertically, change-focus * 5, close-focused-pane and quit
-    //
-    // (ctrl-b + ctrl-n + ctrl-n + ctrl-p + ctrl-n + ctrl-n + ctrl-j + ctrl-p + ctrl-j + ctrl-p * 2
-    // + ctrl-n + ctrl-p * 5 + ctrl-x + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 14, 14, 16, 14, 14, 10, 16, 10, 16, 16, 14, 16, 16, 16, 16, 16, 24, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        RESIZE_DOWN,
+        MOVE_FOCUS,
+        RESIZE_DOWN,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -312,13 +391,27 @@ pub fn close_pane_with_multiple_panes_to_the_left_away_from_screen_edges() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-vertically, split-horizontally * 2, change-focus, split-horizontally * 2, resize-left,
-    // change-focus, resize-left, change-focus * 4, split-horizontally, change-focus * 3,
-    // close-focused pane and quit
-    //
-    // (ctrl-n + ctrl-b + ctrl-b + ctrl-p + ctrl-b + ctrl-b + ctrl-h + ctrl-p + ctrl-h + ctrl-p * 4
-    // + ctrl-b + ctrl-p * 3 + ctrl-x + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 2, 16, 2, 2, 8, 16, 8, 16, 16, 16, 16, 2, 16, 16, 16, 24, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        RESIZE_LEFT,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -347,12 +440,27 @@ pub fn close_pane_with_multiple_panes_to_the_right_away_from_screen_edges() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-vertically, split-horizontally * 2, change-focus, split-horizontally * 2, resize-left,
-    // change-focus, resize-left, change-focus * 2, split-horizontally, change-focus * 5, close-focused-pane and quit
-    //
-    // (ctrl-n + ctrl-b + ctrl-b + ctrl-p + ctrl-b + ctrl-b + ctrl-h + ctrl-p + ctrl-h + ctrl-p * 2
-    // + ctrl-b + ctrl-p * 5 + ctrl-x + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 2, 16, 2, 2, 8, 16, 8, 16, 16, 2, 16, 16, 16, 16, 16, 24, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        RESIZE_LEFT,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        CLOSE_FOCUSED_PANE,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();

--- a/src/tests/integration/compatibility.rs
+++ b/src/tests/integration/compatibility.rs
@@ -7,6 +7,8 @@ use crate::tests::possible_tty_inputs::Bytes;
 use crate::tests::fakes::{FakeInputOutput};
 use crate::tests::utils::get_output_frame_snapshots;
 
+use crate::tests::utils::commands::QUIT;
+
 /*
  * These tests are general compatibility tests for non-trivial scenarios running in the terminal.
  * They use fake TTY input replicated from these scenarios (and so don't actually interact with the
@@ -37,7 +39,7 @@ pub fn run_bandwhich_from_fish_shell() {
     };
     let fixture_name = "fish_and_bandwhich";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
-    fake_input_output.add_terminal_input(&[17]); // quit (ctrl-q)
+    fake_input_output.add_terminal_input(&[QUIT]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -56,7 +58,7 @@ pub fn fish_tab_completion_options() {
     };
     let fixture_name = "fish_tab_completion_options";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
-    fake_input_output.add_terminal_input(&[17]); // quit (ctrl-q)
+    fake_input_output.add_terminal_input(&[QUIT]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -80,7 +82,7 @@ pub fn fish_select_tab_completion_options() {
     };
     let fixture_name = "fish_select_tab_completion_options";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
-    fake_input_output.add_terminal_input(&[17]); // quit (ctrl-q)
+    fake_input_output.add_terminal_input(&[QUIT]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -108,7 +110,8 @@ pub fn vim_scroll_region_down () {
     };
     let fixture_name = "vim_scroll_region_down";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
-    fake_input_output.add_terminal_input(&[17]); // quit (ctrl-q)
+    // fake_input_output.add_terminal_input(&[17]); // quit (ctrl-q)
+    fake_input_output.add_terminal_input(&[QUIT]); // quit (ctrl-q)
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -133,7 +136,7 @@ pub fn vim_ctrl_d() {
     };
     let fixture_name = "vim_ctrl_d";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
-    fake_input_output.add_terminal_input(&[17]); // quit (ctrl-q)
+    fake_input_output.add_terminal_input(&[QUIT]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);
@@ -157,7 +160,7 @@ pub fn vim_ctrl_u() {
     };
     let fixture_name = "vim_ctrl_u";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
-    fake_input_output.add_terminal_input(&[17]); // quit (ctrl-q)
+    fake_input_output.add_terminal_input(&[QUIT]);
     start(Box::new(fake_input_output.clone()), Opt::default());
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
     let snapshots = get_output_frame_snapshots(&output_frames, &fake_win_size);

--- a/src/tests/integration/resize_down.rs
+++ b/src/tests/integration/resize_down.rs
@@ -5,6 +5,15 @@ use crate::{start, Opt};
 use crate::tests::fakes::{FakeInputOutput};
 use crate::tests::utils::get_output_frame_snapshots;
 
+use crate::tests::utils::commands::{
+    SPLIT_HORIZONTALLY,
+    SPLIT_VERTICALLY,
+    RESIZE_DOWN,
+    MOVE_FOCUS,
+    RESIZE_LEFT,
+    QUIT,
+};
+
 fn get_fake_os_input (fake_win_size: &Winsize) -> FakeInputOutput {
     FakeInputOutput::new(fake_win_size.clone())
 }
@@ -27,7 +36,11 @@ pub fn resize_down_with_pane_above() {
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[2, 10, 17]); // split-horizontally, resize-down and quit (ctrl-b + ctrl-j + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -47,14 +60,18 @@ pub fn resize_down_with_pane_below() {
     // │           │                  │           │
     // └───────────┘                  └───────────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[2, 16, 10, 17]); // split-horizontally, change-focus, resize-down and quit (ctrl-b + ctrl-p + ctrl-j + ctrl-q)
+    fake_input_output.add_terminal_input(&[SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -77,15 +94,21 @@ pub fn resize_down_with_panes_above_and_below() {
     // │           │                  │           │
     // └───────────┘                  └───────────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-horizontally * 2, change-focus * 2, resize-down and quit (ctrl-n * 2 + ctrl-p * 2 + ctrl-j + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 2, 16, 16, 10, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -105,7 +128,7 @@ pub fn resize_down_with_multiple_panes_above() {
     // │███████████│                    │███████████│
     // └───────────┘                    └───────────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -113,8 +136,15 @@ pub fn resize_down_with_multiple_panes_above() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b + ctrl-p + ctrl-n + ctrl-p * 2 + ctrl-j + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 16, 14, 16, 16, 10, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -135,7 +165,7 @@ pub fn resize_down_with_panes_above_aligned_left_with_current_pane() {
     // │     │█████│                    │     │█████│
     // └─────┴─────┘                    └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -143,8 +173,17 @@ pub fn resize_down_with_panes_above_aligned_left_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p * 3, ctrl-j + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 16, 16, 10, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -165,7 +204,7 @@ pub fn resize_down_with_panes_below_aligned_left_with_current_pane() {
     // │     │     │                    │     │     │
     // └─────┴─────┘                    └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -173,8 +212,16 @@ pub fn resize_down_with_panes_below_aligned_left_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p + ctrl-p + ctrl-j + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 16, 10, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -195,7 +242,7 @@ pub fn resize_down_with_panes_above_aligned_right_with_current_pane() {
     // │█████│     │                    │█████│     │
     // └─────┴─────┘                    └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -203,8 +250,14 @@ pub fn resize_down_with_panes_above_aligned_right_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-j + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 10, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -225,7 +278,7 @@ pub fn resize_down_with_panes_below_aligned_right_with_current_pane() {
     // │     │     │                    │     │     │
     // └─────┴─────┘                    └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -233,9 +286,15 @@ pub fn resize_down_with_panes_below_aligned_right_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // split-vertically, split_horizontally, change-focus, split-horizontally, resize-right and quit
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p, ctrl-j + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 10, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -256,7 +315,7 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_current_pane() {
     // │   │███│   │                    │   │███│   │
     // └───┴───┴───┘                    └───┴───┴───┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -264,8 +323,18 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n * 2 + ctrl-b + ctrl-p + ctrl-b + ctrl-p * 2 + ctrl-b + ctrl-j + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 14, 2, 16, 2, 16, 16, 2, 10, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -286,7 +355,7 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_current_pane() {
     // │   │   │   │                    │   │   │   │
     // └───┴───┴───┘                    └───┴───┴───┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -294,8 +363,20 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n * 2 + ctrl-b + ctrl-p + ctrl-b + ctrl-p * 2 + ctrl-b + ctrl-p * 2 + ctrl-j + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 14, 2, 16, 2, 16, 16, 2, 16, 16, 10, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -324,9 +405,35 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_panes_to_the_lef
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n * 2 + ctrl-p + ctrl-h * 3 + ctrl-b + ctrl-p * 3 + ctrl-b + ctrl-p * 2 + ctrl-b +
-    // ctrl-n * 2 + ctrl-p * 6 + ctrl-h * 2 + ctrl-p + ctrl-j + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 14, 16, 8, 8, 8, 2, 16, 16, 16, 2, 16, 16, 2, 14, 14, 16, 16, 16, 16, 16, 16, 8, 8, 16, 10, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        MOVE_FOCUS,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -347,7 +454,7 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_to_the_left_and_
     // │ │       │ │                    │ │       │ │
     // └─┴───────┴─┘                    └─┴───────┴─┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 40,
         ws_xpixel: 0,
@@ -355,10 +462,37 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_to_the_left_and_
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n * 2 + ctrl-p + ctrl-h * 3 + ctrl-b + ctrl-p * 3 + ctrl-b + ctrl-p * 2 + ctrl-b +
-    // ctrl-p * 2 +
-    // ctrl-n * 2 + ctrl-p * 2 + ctrl-h * 2 + ctrl-p * 5 + ctrl-j + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 14, 16, 8, 8, 8, 2, 16, 16, 16, 2, 16, 16, 2, 16, 16, 14, 14, 16, 16, 8, 8, 16, 16, 16, 16, 16, 10, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_DOWN,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 

--- a/src/tests/integration/resize_left.rs
+++ b/src/tests/integration/resize_left.rs
@@ -5,6 +5,15 @@ use crate::{start, Opt};
 use crate::tests::fakes::{FakeInputOutput};
 use crate::tests::utils::get_output_frame_snapshots;
 
+use crate::tests::utils::commands::{
+    SPLIT_HORIZONTALLY,
+    SPLIT_VERTICALLY,
+    RESIZE_UP,
+    MOVE_FOCUS,
+    RESIZE_LEFT,
+    QUIT,
+};
+
 fn get_fake_os_input (fake_win_size: &Winsize) -> FakeInputOutput {
     FakeInputOutput::new(fake_win_size.clone())
 }
@@ -17,14 +26,18 @@ pub fn resize_left_with_pane_to_the_left() {
     // │     │█████│                    │   │███████│
     // └─────┴─────┘                    └───┴───────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[14, 8, 17]); // split-vertically, resize-left and quit (ctrl-n + ctrl-h + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -42,14 +55,19 @@ pub fn resize_left_with_pane_to_the_right() {
     // │█████│     │                    │███│       │
     // └─────┴─────┘                    └───┴───────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[14, 16, 8, 17]); // split-vertically, change-focus resize-left and quit (ctrl-n + ctrl-p + ctrl-h + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -67,15 +85,21 @@ pub fn resize_left_with_panes_to_the_left_and_right() {
     // │     │█████│     │                    │     │███│       │
     // └─────┴─────┴─────┘                    └─────┴───┴───────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-vertically * 2, change-focus * 2, resize-right and quit (ctrl-n * 2 + ctrl-p * 2 + ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 14, 16, 16, 8, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -93,7 +117,7 @@ pub fn resize_left_with_multiple_panes_to_the_left() {
     // │     │█████│                    │   │███████│
     // └─────┴─────┘                    └───┴───────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -101,8 +125,15 @@ pub fn resize_left_with_multiple_panes_to_the_left() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-p + ctrl-b + ctrl-p * 2 + ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 16, 2, 16, 16, 8, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -121,7 +152,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_with_current_pane() {
     // │     │█████│                    │   │███████│
     // └─────┴─────┘                    └───┴───────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -129,8 +160,17 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p * 3, ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 16, 16, 8, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -149,7 +189,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_with_current_pane() {
     // │█████│     │                    │███│       │
     // └─────┴─────┘                    └───┴───────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -157,8 +197,14 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 8, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -177,7 +223,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_bottom_with_current_pane() {
     // │     │     │                    │     │     │
     // └─────┴─────┘                    └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -185,8 +231,16 @@ pub fn resize_left_with_panes_to_the_left_aligned_bottom_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p * 2, ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 16, 8, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -205,7 +259,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     // │     │     │                    │     │     │
     // └─────┴─────┘                    └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -213,9 +267,15 @@ pub fn resize_left_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // split-vertically, split_horizontally, change-focus, split-horizontally, resize-right and quit
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p, ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 8, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -236,7 +296,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_current_pa
     // │     │     │                    │     │     │
     // └─────┴─────┘                    └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -244,8 +304,18 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_current_pa
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b * 2 + ctrl-n + ctrl-p + ctrl-n + ctrl-p * 2 + ctrl-n + ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 2, 14, 16, 14, 16, 16, 14, 8, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -266,7 +336,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_current_p
     // │     │     │                    │     │     │
     // └─────┴─────┘                    └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -274,8 +344,20 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_current_p
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b * 2 + ctrl-n + ctrl-p + ctrl-n + ctrl-p * 2 + ctrl-n + ctrl-p * 2 + ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 2, 14, 16, 14, 16, 16, 14, 16, 16, 8, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -304,9 +386,35 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abov
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b * 2 + ctrl-p + ctrl-k * 3 + ctrl-n + ctrl-p * 3 + ctrl-n + ctrl-p * 2 + ctrl-n +
-    // ctrl-b * 2 + ctrl-p * 7 + ctrl-k * 2 + ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 2, 16, 11, 11, 11, 14, 16, 16, 16, 14, 16, 16, 14, 2, 2, 16, 16, 16, 16, 16, 16, 16, 11, 11, 8, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        RESIZE_UP,
+        RESIZE_UP,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        RESIZE_UP,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -335,10 +443,37 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_panes_abo
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b * 2 + ctrl-p + ctrl-k * 3 + ctrl-n + ctrl-p * 3 + ctrl-n + ctrl-p * 2 + ctrl-n +
-    // ctrl-p * 2 +
-    // ctrl-b * 2 + ctrl-p * 7 + ctrl-k * 2 + ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 2, 16, 11, 11, 11, 14, 16, 16, 16, 14, 16, 16, 14, 16, 16, 2, 2, 16, 16, 16, 16, 16, 16, 16, 11, 11, 8, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        RESIZE_UP,
+        RESIZE_UP,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        RESIZE_UP,
+        RESIZE_LEFT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 

--- a/src/tests/integration/resize_right.rs
+++ b/src/tests/integration/resize_right.rs
@@ -5,6 +5,15 @@ use crate::{start, Opt};
 use crate::tests::fakes::{FakeInputOutput};
 use crate::tests::utils::get_output_frame_snapshots;
 
+use crate::tests::utils::commands::{
+    SPLIT_HORIZONTALLY,
+    SPLIT_VERTICALLY,
+    RESIZE_UP,
+    MOVE_FOCUS,
+    RESIZE_RIGHT,
+    QUIT,
+};
+
 fn get_fake_os_input (fake_win_size: &Winsize) -> FakeInputOutput {
     FakeInputOutput::new(fake_win_size.clone())
 }
@@ -17,14 +26,18 @@ pub fn resize_right_with_pane_to_the_left() {
     // │     │█████│                   │       │███│
     // └─────┴─────┘                   └───────┴───┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[14, 12, 17]); // split-vertically, resize-right and quit (ctrl-n + ctrl-l + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -42,14 +55,19 @@ pub fn resize_right_with_pane_to_the_right() {
     // │█████│     │                   │███████│   │
     // └─────┴─────┘                   └───────┴───┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[14, 16, 12, 17]); // split-vertically, change-focus resize-right and quit (ctrl-n + ctrl-p + ctrl-l + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -67,15 +85,21 @@ pub fn resize_right_with_panes_to_the_left_and_right() {
     // │     │█████│     │                   │     │███████│   │
     // └─────┴─────┴─────┘                   └─────┴───────┴───┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-vertically * 2, change-focus * 2, resize-right and quit (ctrl-n * 2 + ctrl-p * 2 + ctrl-l + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 14, 16, 16, 12, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -93,7 +117,7 @@ pub fn resize_right_with_multiple_panes_to_the_left() {
     // │     │█████│                   │       │███│
     // └─────┴─────┘                   └───────┴───┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -101,8 +125,15 @@ pub fn resize_right_with_multiple_panes_to_the_left() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-p + ctrl-b + ctrl-p * 2 + ctrl-l + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 16, 2, 16, 16, 12, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -121,7 +152,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_with_current_pane() {
     // │     │█████│                   │       │███│
     // └─────┴─────┘                   └───────┴───┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -129,8 +160,17 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p * 3, ctrl-l + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 16, 16, 12, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -149,7 +189,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_with_current_pane() {
     // │█████│     │                   │███████│   │
     // └─────┴─────┘                   └───────┴───┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -157,8 +197,14 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-l + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 12, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -177,7 +223,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_bottom_with_current_pane() {
     // │     │     │                   │     │     │
     // └─────┴─────┘                   └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -185,8 +231,16 @@ pub fn resize_right_with_panes_to_the_left_aligned_bottom_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p * 2, ctrl-l + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 16, 12, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -205,7 +259,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     // │     │     │                   │     │     │
     // └─────┴─────┘                   └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -213,9 +267,15 @@ pub fn resize_right_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // split-vertically, split_horizontally, change-focus, split-horizontally, resize-right and quit
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p, ctrl-l + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 12, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -236,7 +296,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_current_p
     // │     │     │                   │     │     │
     // └─────┴─────┘                   └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -244,8 +304,18 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_current_p
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b * 2 + ctrl-n + ctrl-p + ctrl-n + ctrl-p * 2 + ctrl-n + ctrl-l + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 2, 14, 16, 14, 16, 16, 14, 12, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        RESIZE_RIGHT,
+        QUIT
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -266,7 +336,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_current_
     // │     │     │                   │     │     │
     // └─────┴─────┘                   └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -274,8 +344,20 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_current_
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b * 2 + ctrl-n + ctrl-p + ctrl-n + ctrl-p * 2 + ctrl-n + ctrl-p * 2 + ctrl-l + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 2, 14, 16, 14, 16, 16, 14, 16, 16, 12, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -296,7 +378,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abo
     // ├─────┼─────┤                   ├─────┬─┴───┤
     // └─────┴─────┘                   └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 40,
         ws_xpixel: 0,
@@ -304,9 +386,35 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abo
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b * 2 + ctrl-p + ctrl-k * 3 + ctrl-n + ctrl-p * 3 + ctrl-n + ctrl-p * 2 + ctrl-n +
-    // ctrl-b * 2 + ctrl-p * 7 + ctrl-k * 2 + ctrl-l + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 2, 16, 11, 11, 11, 14, 16, 16, 16, 14, 16, 16, 14, 2, 2, 16, 16, 16, 16, 16, 16, 16, 11, 11, 12, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        RESIZE_UP,
+        RESIZE_UP,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        RESIZE_UP,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -327,7 +435,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_panes_ab
     // ├─────┼─────┤                   ├─────┬─┴───┤
     // └─────┴─────┘                   └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 40,
         ws_xpixel: 0,
@@ -335,10 +443,37 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_panes_ab
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b * 2 + ctrl-p + ctrl-k * 3 + ctrl-n + ctrl-p * 3 + ctrl-n + ctrl-p * 2 + ctrl-n +
-    // ctrl-p * 2 +
-    // ctrl-b * 2 + ctrl-p * 7 + ctrl-k * 2 + ctrl-l + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 2, 16, 11, 11, 11, 14, 16, 16, 16, 14, 16, 16, 14, 16, 16, 2, 2, 16, 16, 16, 16, 16, 16, 16, 11, 11, 12, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        RESIZE_UP,
+        RESIZE_UP,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        RESIZE_UP,
+        RESIZE_RIGHT,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 

--- a/src/tests/integration/resize_up.rs
+++ b/src/tests/integration/resize_up.rs
@@ -5,6 +5,15 @@ use crate::{start, Opt};
 use crate::tests::fakes::{FakeInputOutput};
 use crate::tests::utils::get_output_frame_snapshots;
 
+use crate::tests::utils::commands::{
+    SPLIT_HORIZONTALLY,
+    SPLIT_VERTICALLY,
+    RESIZE_UP,
+    MOVE_FOCUS,
+    RESIZE_LEFT,
+    QUIT,
+};
+
 fn get_fake_os_input (fake_win_size: &Winsize) -> FakeInputOutput {
     FakeInputOutput::new(fake_win_size.clone())
 }
@@ -19,14 +28,18 @@ pub fn resize_up_with_pane_above() {
     // │███████████│                │███████████│
     // └───────────┘                └───────────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[2, 11, 17]); // split-horizontally, resize-up and quit (ctrl-b + ctrl-k + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        RESIZE_UP,
+        QUIT
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -46,14 +59,19 @@ pub fn resize_up_with_pane_below() {
     // │           │                │           │
     // └───────────┘                └───────────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[2, 16, 11, 17]); // split-horizontally, change-focus, resize-up and quit (ctrl-b + ctrl-p + ctrl-k + ctrl-q)
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -76,15 +94,20 @@ pub fn resize_up_with_panes_above_and_below() {
     // │           │                │           │
     // └───────────┘                └───────────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    // split-horizontally * 2, change-focus * 2, resize-up and quit (ctrl-n * 2 + ctrl-p * 2 + ctrl-h + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 2, 16, 16, 11, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS, MOVE_FOCUS,
+        RESIZE_UP,
+        QUIT,
+    ]);
     start(Box::new(fake_input_output.clone()), Opt::default());
 
     let output_frames = fake_input_output.stdout_writer.output_frames.lock().unwrap();
@@ -103,7 +126,7 @@ pub fn resize_up_with_multiple_panes_above() {
     // │███████████│                 │███████████│
     // └───────────┘                 └───────────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -111,8 +134,15 @@ pub fn resize_up_with_multiple_panes_above() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-b + ctrl-p + ctrl-n + ctrl-p * 2 + ctrl-k + ctrl-q)
-    fake_input_output.add_terminal_input(&[2, 16, 14, 16, 16, 11, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -131,7 +161,7 @@ pub fn resize_up_with_panes_above_aligned_left_with_current_pane() {
     // │     │█████│                  │     │█████│
     // └─────┴─────┘                  └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -139,8 +169,17 @@ pub fn resize_up_with_panes_above_aligned_left_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p * 3, ctrl-k + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 16, 16, 11, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -161,7 +200,7 @@ pub fn resize_up_with_panes_below_aligned_left_with_current_pane() {
     // │     │     │                  │     │     │
     // └─────┴─────┘                  └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -169,8 +208,16 @@ pub fn resize_up_with_panes_below_aligned_left_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p + ctrl-p + ctrl-k + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 16, 11, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        QUIT
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -191,7 +238,7 @@ pub fn resize_up_with_panes_above_aligned_right_with_current_pane() {
     // │█████│     │                  │█████│     │
     // └─────┴─────┘                  └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -199,8 +246,14 @@ pub fn resize_up_with_panes_above_aligned_right_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-k + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 11, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        RESIZE_UP,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -221,7 +274,7 @@ pub fn resize_up_with_panes_below_aligned_right_with_current_pane() {
     // │     │     │                  │     │     │
     // └─────┴─────┘                  └─────┴─────┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -229,9 +282,15 @@ pub fn resize_up_with_panes_below_aligned_right_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // split-vertically, split_horizontally, change-focus, split-horizontally, resize-right and quit
-    // (ctrl-n + ctrl-b + ctrl-p + ctrl-b + ctrl-p, ctrl-k + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 2, 16, 2, 16, 11, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -252,7 +311,7 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_current_pane() {
     // │   │███│   │                  │   │███│   │
     // └───┴───┴───┘                  └───┴───┴───┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -260,8 +319,18 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n * 2 + ctrl-b + ctrl-p + ctrl-b + ctrl-p * 2 + ctrl-b + ctrl-k + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 14, 2, 16, 2, 16, 16, 2, 11, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        RESIZE_UP,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -282,7 +351,7 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_current_pane() {
     // │   │   │   │                  │   │   │   │
     // └───┴───┴───┘                  └───┴───┴───┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 20,
         ws_xpixel: 0,
@@ -290,8 +359,20 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_current_pane() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n * 2 + ctrl-b + ctrl-p + ctrl-b + ctrl-p * 2 + ctrl-b + ctrl-p * 2 + ctrl-k + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 14, 2, 16, 2, 16, 16, 2, 16, 16, 11, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        QUIT
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -320,9 +401,35 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_panes_to_the_left_
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n * 2 + ctrl-p + ctrl-h * 3 + ctrl-b + ctrl-p * 3 + ctrl-b + ctrl-p * 2 + ctrl-b +
-    // ctrl-n * 2 + ctrl-p * 6 + ctrl-h * 2 + ctrl-p + ctrl-k + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 14, 16, 8, 8, 8, 2, 16, 16, 16, 2, 16, 16, 2, 14, 14, 16, 16, 16, 16, 16, 16, 8, 8, 16, 11, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 
@@ -343,7 +450,7 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_to_the_left_and_ri
     // │ │       │ │                  │ │       │ │
     // └─┴───────┴─┘                  └─┴───────┴─┘
     // █ == focused pane
-    let fake_win_size = Winsize { // TODO: combine with above
+    let fake_win_size = Winsize {
         ws_col: 121,
         ws_row: 40,
         ws_xpixel: 0,
@@ -351,10 +458,37 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_to_the_left_and_ri
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
-    // (ctrl-n * 2 + ctrl-p + ctrl-h * 3 + ctrl-b + ctrl-p * 3 + ctrl-b + ctrl-p * 2 + ctrl-b +
-    // ctrl-p * 2 +
-    // ctrl-n * 2 + ctrl-p * 2 + ctrl-h * 2 + ctrl-p * 5 + ctrl-k + ctrl-q)
-    fake_input_output.add_terminal_input(&[14, 14, 16, 8, 8, 8, 2, 16, 16, 16, 2, 16, 16, 2, 16, 16, 14, 14, 16, 16, 8, 8, 16, 16, 16, 16, 16, 11, 17]);
+    fake_input_output.add_terminal_input(&[
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_HORIZONTALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        SPLIT_VERTICALLY,
+        SPLIT_VERTICALLY,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_LEFT,
+        RESIZE_LEFT,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        MOVE_FOCUS,
+        RESIZE_UP,
+        QUIT,
+    ]);
 
     start(Box::new(fake_input_output.clone()), Opt::default());
 

--- a/src/tests/possible_tty_inputs.rs
+++ b/src/tests/possible_tty_inputs.rs
@@ -28,10 +28,6 @@ impl Bytes {
             read_position: 0
         }
     }
-    pub fn content(mut self, content: Vec<u8>) -> Self {
-        self.content = content;
-        self
-    }
     pub fn content_from_str(mut self, content: &[&'static str]) -> Self {
         let mut content_as_bytes = vec![];
         for line in content {

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -35,3 +35,18 @@ pub fn get_output_frame_snapshots(output_frames: &[Vec<u8>], win_size: &Winsize)
     snapshots
 }
 
+pub mod commands {
+    pub const SPLIT_HORIZONTALLY: [u8; 10] = [2, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-b
+    pub const SPLIT_VERTICALLY: [u8; 10] = [14, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-n
+    pub const RESIZE_DOWN: [u8; 10] = [10, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-j
+    pub const RESIZE_UP: [u8; 10] = [11, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-k
+    pub const MOVE_FOCUS: [u8; 10] = [16, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-p
+    pub const RESIZE_LEFT: [u8; 10] = [8, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-h
+    pub const RESIZE_RIGHT: [u8; 10] = [12, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-l
+    pub const SPAWN_TERMINAL: [u8; 10] = [26, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-z
+    pub const QUIT: [u8; 10] = [17, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-q
+    pub const SCROLL_UP: [u8; 10] = [27, 91, 53, 94, 0, 0, 0, 0, 0, 0]; // ctrl-PgUp
+    pub const SCROLL_DOWN: [u8; 10] = [27, 91, 54, 94, 0, 0, 0, 0, 0, 0]; // ctrl-PgDown
+    pub const CLOSE_FOCUSED_PANE: [u8; 10] = [24, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-x
+    pub const TOGGLE_ACTIVE_TERMINAL_FULLSCREEN: [u8; 10] = [5, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // ctrl-e
+}


### PR DESCRIPTION
## Some fixes here:
* change scroll shortcuts to ctrl-pgup and ctrl-pgdown because ctrl-[ and ctrl-] were colliding with esc.
* do not send trailing zeros to terminal because it was messing things up
* fix test infrastructure to be able to support characters with more than one byte (eg. ctrl-pgup and ctrl-pgdown). This also introduces some much needed refactoring and clarity to the tests.