### PR TITLE
fix(compatibility): do not break starship multiline prompt

### DIFF
--- a/src/terminal_pane/scroll.rs
+++ b/src/terminal_pane/scroll.rs
@@ -338,6 +338,9 @@ impl Scroll {
             self.cursor_position.move_backwards(count);
         }
     }
+    pub fn move_cursor_to_beginning_of_linewrap(&mut self) {
+        self.cursor_position.move_to_beginning_of_linewrap();
+    }
     pub fn move_cursor_to_beginning_of_canonical_line(&mut self) {
         self.cursor_position.move_to_beginning_of_canonical_line();
     }

--- a/src/terminal_pane/terminal_pane.rs
+++ b/src/terminal_pane/terminal_pane.rs
@@ -260,7 +260,7 @@ impl TerminalPane {
         self.should_render = true;
     }
     fn move_to_beginning_of_line (&mut self) {
-        self.scroll.move_cursor_to_beginning_of_canonical_line();
+        self.scroll.move_cursor_to_beginning_of_linewrap();
     }
     fn move_cursor_backwards(&mut self, count: usize) {
         self.scroll.move_cursor_backwards(count);


### PR DESCRIPTION
This happened because apparently a carriage return should go to the beginning of a line-wrap and not a canonical line. Starship is depending on this behaviour for a multi-line prompt.