### PR TITLE
fix(colors): send full style reset in diff

### DIFF
--- a/src/terminal_pane/terminal_character.rs
+++ b/src/terminal_pane/terminal_character.rs
@@ -153,6 +153,32 @@ impl CharacterStyles {
     }
     pub fn update_and_return_diff(&mut self, new_styles: &CharacterStyles) -> Option<CharacterStyles> {
         let mut diff: Option<CharacterStyles> = None;
+
+        if new_styles.foreground == Some(AnsiCode::Reset) &&
+            new_styles.background == Some(AnsiCode::Reset) &&
+            new_styles.strike == Some(AnsiCode::Reset) &&
+            new_styles.hidden == Some(AnsiCode::Reset) &&
+            new_styles.reverse == Some(AnsiCode::Reset) &&
+            new_styles.fast_blink == Some(AnsiCode::Reset) &&
+            new_styles.slow_blink == Some(AnsiCode::Reset) &&
+            new_styles.underline == Some(AnsiCode::Reset) &&
+            new_styles.bold == Some(AnsiCode::Reset) &&
+            new_styles.dim == Some(AnsiCode::Reset) &&
+            new_styles.italic == Some(AnsiCode::Reset) {
+                self.foreground = Some(AnsiCode::Reset);
+                self.background = Some(AnsiCode::Reset);
+                self.strike = Some(AnsiCode::Reset);
+                self.hidden = Some(AnsiCode::Reset);
+                self.reverse = Some(AnsiCode::Reset);
+                self.fast_blink = Some(AnsiCode::Reset);
+                self.slow_blink = Some(AnsiCode::Reset);
+                self.underline = Some(AnsiCode::Reset);
+                self.bold = Some(AnsiCode::Reset);
+                self.dim = Some(AnsiCode::Reset);
+                self.italic = Some(AnsiCode::Reset);
+                return Some(*new_styles)
+        };
+
         if self.foreground != new_styles.foreground {
             if let Some(new_diff) = diff.as_mut() {
                 diff = Some(new_diff.foreground(new_styles.foreground));


### PR DESCRIPTION
This addresses https://github.com/mosaic-org/mosaic/issues/15

What caused this issue was that apparently one is able to set the font color using the bold code. As in, while `[1m` is "set to bold", `[1;32m` is "set to red bold". But the bold reset code `[22m` (that which I initially thought would reset whatever one places in `[1m`) only resets the bold and not the red.

Because of that assumption of mine, in the case of starship we were only sending the reset code for bold and thus the color stayed red when it wasn't supposed to.

To solve this, when we decide which styles to send to a new character (we do this by diffing the styles with the previous character, because styles stick around until they are reset), if the new character is a full reset, we send a full reset rather than bothering with the diff.