### PR TITLE
fix(ux): properly echo characters and do not mess up exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -341,6 +341,7 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: Opt) {
     let goto_start_of_last_line = format!("\u{1b}[{};{}H", full_screen_ws.ws_row, 1);
     let goodbye_message = format!("{}\n{}Bye from Mosaic!", goto_start_of_last_line, reset_style);
 
+    os_input.unset_raw_mode(0);
     os_input.get_stdout_writer().write(goodbye_message.as_bytes()).unwrap();
     os_input.get_stdout_writer().flush().unwrap();
 }

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -14,6 +14,7 @@ pub enum IoEvent {
     Kill(RawFd),
     SetTerminalSizeUsingFd(RawFd, u16, u16),
     IntoRawMode(RawFd),
+    UnsetRawMode(RawFd),
     TcDrain(RawFd),
 }
 
@@ -122,6 +123,9 @@ impl OsApi for FakeInputOutput {
     }
     fn into_raw_mode(&mut self, pid: RawFd) {
         self.io_events.lock().unwrap().push(IoEvent::IntoRawMode(pid));
+    }
+    fn unset_raw_mode(&mut self, pid: RawFd) {
+        self.io_events.lock().unwrap().push(IoEvent::UnsetRawMode(pid));
     }
     fn spawn_terminal(&mut self, _file_to_open: Option<PathBuf>) -> (RawFd, RawFd) {
         let next_terminal_id = { self.read_buffers.lock().unwrap().keys().len() as RawFd + 1 };


### PR DESCRIPTION
This was happening for two reasons:
1. We set the attributes of each terminal we opened to match those of the current "main" terminal. This meant that once we entered raw mode (no echo, get input character by character, etc.) for the main terminal, we also set it for each pane we opened.
2. We didn't unset raw mode when we exited

This was fixed by keeping the original termios object that holds all the terminal attribute before we change anything, and using it to set all the terminals. (And also, restoring it once we exit)