### PR TITLE
fix(atomicity): allow async vte events sending to fail

### DIFF
--- a/src/pty_bus.rs
+++ b/src/pty_bus.rs
@@ -86,10 +86,14 @@ impl VteEventSender {
 
 impl vte::Perform for VteEventSender {
     fn print(&mut self, c: char) {
-        let _ = self.sender.send(ScreenInstruction::Pty(self.id, VteEvent::Print(c)));
+        let _ = self
+            .sender
+            .send(ScreenInstruction::Pty(self.id, VteEvent::Print(c)));
     }
     fn execute(&mut self, byte: u8) {
-        let _ = self.sender.send(ScreenInstruction::Pty(self.id, VteEvent::Execute(byte)));
+        let _ = self
+            .sender
+            .send(ScreenInstruction::Pty(self.id, VteEvent::Execute(byte)));
     }
 
     fn hook(&mut self, params: &[i64], intermediates: &[u8], ignore: bool, c: char) {
@@ -101,11 +105,15 @@ impl vte::Perform for VteEventSender {
     }
 
     fn put(&mut self, byte: u8) {
-        let _ = self.sender.send(ScreenInstruction::Pty(self.id, VteEvent::Put(byte)));
+        let _ = self
+            .sender
+            .send(ScreenInstruction::Pty(self.id, VteEvent::Put(byte)));
     }
 
     fn unhook(&mut self) {
-        let _ = self.sender.send(ScreenInstruction::Pty(self.id, VteEvent::Unhook));
+        let _ = self
+            .sender
+            .send(ScreenInstruction::Pty(self.id, VteEvent::Unhook));
     }
 
     fn osc_dispatch(&mut self, params: &[&[u8]], bell_terminated: bool) {

--- a/src/pty_bus.rs
+++ b/src/pty_bus.rs
@@ -86,14 +86,10 @@ impl VteEventSender {
 
 impl vte::Perform for VteEventSender {
     fn print(&mut self, c: char) {
-        self.sender
-            .send(ScreenInstruction::Pty(self.id, VteEvent::Print(c)))
-            .unwrap();
+        let _ = self.sender.send(ScreenInstruction::Pty(self.id, VteEvent::Print(c)));
     }
     fn execute(&mut self, byte: u8) {
-        self.sender
-            .send(ScreenInstruction::Pty(self.id, VteEvent::Execute(byte)))
-            .unwrap();
+        let _ = self.sender.send(ScreenInstruction::Pty(self.id, VteEvent::Execute(byte)));
     }
 
     fn hook(&mut self, params: &[i64], intermediates: &[u8], ignore: bool, c: char) {
@@ -101,26 +97,22 @@ impl vte::Perform for VteEventSender {
         let intermediates = intermediates.iter().copied().collect();
         let instruction =
             ScreenInstruction::Pty(self.id, VteEvent::Hook(params, intermediates, ignore, c));
-        self.sender.send(instruction).unwrap();
+        let _ = self.sender.send(instruction);
     }
 
     fn put(&mut self, byte: u8) {
-        self.sender
-            .send(ScreenInstruction::Pty(self.id, VteEvent::Put(byte)))
-            .unwrap();
+        let _ = self.sender.send(ScreenInstruction::Pty(self.id, VteEvent::Put(byte)));
     }
 
     fn unhook(&mut self) {
-        self.sender
-            .send(ScreenInstruction::Pty(self.id, VteEvent::Unhook))
-            .unwrap();
+        let _ = self.sender.send(ScreenInstruction::Pty(self.id, VteEvent::Unhook));
     }
 
     fn osc_dispatch(&mut self, params: &[&[u8]], bell_terminated: bool) {
         let params = params.iter().map(|p| p.to_vec()).collect();
         let instruction =
             ScreenInstruction::Pty(self.id, VteEvent::OscDispatch(params, bell_terminated));
-        self.sender.send(instruction).unwrap();
+        let _ = self.sender.send(instruction);
     }
 
     fn csi_dispatch(&mut self, params: &[i64], intermediates: &[u8], ignore: bool, c: char) {
@@ -130,14 +122,14 @@ impl vte::Perform for VteEventSender {
             self.id,
             VteEvent::CsiDispatch(params, intermediates, ignore, c),
         );
-        self.sender.send(instruction).unwrap();
+        let _ = self.sender.send(instruction);
     }
 
     fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
         let intermediates = intermediates.iter().copied().collect();
         let instruction =
             ScreenInstruction::Pty(self.id, VteEvent::EscDispatch(intermediates, ignore, byte));
-        self.sender.send(instruction).unwrap();
+        let _ = self.sender.send(instruction);
     }
 }
 


### PR DESCRIPTION
This change means that the asynchronous events we get from listening to the pty are allowed to fail. The only time they fail is if the pty_bus thread is dead, in which case the app is either exiting or has crashed anyway. The former happens sometimes in our tests, which makes the CI fail. This should (hopefully) fix that.