### PR TITLE
Add custom panic hook. Print backtrace and thread, error info on panic.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,7 @@ name = "mosaic"
 version = "0.1.0"
 dependencies = [
  "async-std",
+ "backtrace",
  "bincode",
  "futures",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,6 @@ termios = "0.3"
 unicode-truncate = "0.1.1"
 unicode-width = "0.1.8"
 vte = "0.8.0"
-futures = "0.3.5"
-serde = { version = "1.0", features = ["derive"] }
-bincode = "1.3.1"
-structopt = "0.3"
-serde_yaml = "0.8"
-serde_json = "1.0"
 
 [dependencies.async-std]
 version = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,19 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-termios = "0.3"
+backtrace = "0.3.55"
+bincode = "1.3.1"
+futures = "0.3.5"
 libc = "0.2"
 nix = "0.17.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.8"
 signal-hook = "0.1.10"
-unicode-width = "0.1.8"
+structopt = "0.3"
+termios = "0.3"
 unicode-truncate = "0.1.1"
+unicode-width = "0.1.8"
 vte = "0.8.0"
 futures = "0.3.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,47 @@
+use crate::AppInstruction;
+use backtrace::Backtrace;
+use std::panic::PanicInfo;
+use std::sync::mpsc::SyncSender;
+use std::{process, thread};
+
+pub fn handle_panic(info: &PanicInfo<'_>, send_app_instructions: &SyncSender<AppInstruction>) {
+    let backtrace = Backtrace::new();
+    let thread = thread::current();
+    let thread = thread.name().unwrap_or("unnamed");
+
+    let msg = match info.payload().downcast_ref::<&'static str>() {
+        Some(s) => *s,
+        None => match info.payload().downcast_ref::<String>() {
+            Some(s) => &**s,
+            None => "Box<Any>",
+        },
+    };
+
+    let backtrace = match info.location() {
+        Some(location) => {
+            format!(
+                "\nthread '{}' panicked at '{}': {}:{}\n{:?}",
+                thread,
+                msg,
+                location.file(),
+                location.line(),
+                backtrace
+            )
+        }
+        None => {
+            format!(
+                "\nthread '{}' panicked at '{}'\n{:?}",
+                thread, msg, backtrace
+            )
+        }
+    };
+
+    if thread == "main" {
+        println!("{}", backtrace);
+        process::exit(1);
+    } else {
+        send_app_instructions
+            .send(AppInstruction::Error(backtrace))
+            .unwrap();
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 /// Module for handling input
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{Sender, SyncSender};
 
 use crate::os_input_output::OsApi;
 use crate::pty_bus::PtyInstruction;
@@ -13,7 +13,7 @@ struct InputHandler {
     command_is_executing: CommandIsExecuting,
     send_screen_instructions: Sender<ScreenInstruction>,
     send_pty_instructions: Sender<PtyInstruction>,
-    send_app_instructions: Sender<AppInstruction>,
+    send_app_instructions: SyncSender<AppInstruction>,
 }
 
 impl InputHandler {
@@ -22,7 +22,7 @@ impl InputHandler {
         command_is_executing: CommandIsExecuting,
         send_screen_instructions: Sender<ScreenInstruction>,
         send_pty_instructions: Sender<PtyInstruction>,
-        send_app_instructions: Sender<AppInstruction>,
+        send_app_instructions: SyncSender<AppInstruction>,
     ) -> Self {
         InputHandler {
             mode: InputMode::Normal,
@@ -241,7 +241,7 @@ pub fn input_loop(
     command_is_executing: CommandIsExecuting,
     send_screen_instructions: Sender<ScreenInstruction>,
     send_pty_instructions: Sender<PtyInstruction>,
-    send_app_instructions: Sender<AppInstruction>,
+    send_app_instructions: SyncSender<AppInstruction>,
 ) {
     let _handler = InputHandler::new(
         os_input,

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,7 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: Opt) {
 
     let send_app_instructions_clone = send_app_instructions.clone();
 
+    #[cfg(not(test))]
     std::panic::set_hook(Box::new(move |info| {
         let backtrace = Backtrace::new();
         let thread = thread::current();
@@ -491,15 +492,12 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: Opt) {
             AppInstruction::Error(backtrace) => {
                 os_input.unset_raw_mode(0);
                 println!("{}", backtrace);
-                #[cfg(not(test))]
-                {
-                    let _ = send_screen_instructions.send(ScreenInstruction::Quit);
-                    let _ = send_pty_instructions.send(PtyInstruction::Quit);
-                    for thread_handler in active_threads {
-                        let _ = thread_handler.join();
-                    }
-                    std::process::exit(1);
+                let _ = send_screen_instructions.send(ScreenInstruction::Quit);
+                let _ = send_pty_instructions.send(PtyInstruction::Quit);
+                for thread_handler in active_threads {
+                    let _ = thread_handler.join();
                 }
+                std::process::exit(1);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 use backtrace::Backtrace;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::{channel, sync_channel, Receiver, Sender, SyncSender};
 use std::thread;
 
 use serde::{Deserialize, Serialize};
@@ -38,7 +38,6 @@ enum ApiCommand {
     SplitHorizontally,
     SplitVertically,
     MoveFocus,
-    Error(String),
 }
 
 #[derive(StructOpt, Debug, Default)]
@@ -97,49 +96,11 @@ pub fn main() {
 
 pub enum AppInstruction {
     Exit,
-    Error,
+    Error(String),
 }
 
 pub fn start(mut os_input: Box<dyn OsApi>, opts: Opt) {
     let mut active_threads = vec![];
-
-    std::panic::set_hook(Box::new(move |info| {
-        let mut stream = UnixStream::connect(MOSAIC_IPC_PIPE).unwrap();
-
-        let backtrace = Backtrace::new();
-        let thread = thread::current();
-        let thread = thread.name().unwrap_or("unnamed");
-
-        let msg = match info.payload().downcast_ref::<&'static str>() {
-            Some(s) => *s,
-            None => match info.payload().downcast_ref::<String>() {
-                Some(s) => &**s,
-                None => "Box<Any>",
-            },
-        };
-
-        let backtrace = match info.location() {
-            Some(location) => {
-                format!(
-                    "\nthread '{}' panicked at '{}': {}:{}\n{:?}",
-                    thread,
-                    msg,
-                    location.file(),
-                    location.line(),
-                    backtrace
-                )
-            }
-            None => {
-                format!(
-                    "\nthread '{}' panicked at '{}'\n{:?}",
-                    thread, msg, backtrace
-                )
-            }
-        };
-
-        let api_command = bincode::serialize(&ApiCommand::Error(backtrace)).unwrap();
-        stream.write_all(&api_command).unwrap();
-    }));
 
     let command_is_executing = CommandIsExecuting::new();
 
@@ -172,6 +133,49 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: Opt) {
         opts.debug,
     );
     let maybe_layout = opts.layout.map(Layout::new);
+
+    let send_app_instructions_clone = send_app_instructions.clone();
+
+    std::panic::set_hook(Box::new(move |info| {
+        let backtrace = Backtrace::new();
+        let thread = thread::current();
+        let thread = thread.name().unwrap_or("unnamed");
+
+        let msg = match info.payload().downcast_ref::<&'static str>() {
+            Some(s) => *s,
+            None => match info.payload().downcast_ref::<String>() {
+                Some(s) => &**s,
+                None => "Box<Any>",
+            },
+        };
+
+        let backtrace = match info.location() {
+            Some(location) => {
+                format!(
+                    "\nthread '{}' panicked at '{}': {}:{}\n{:?}",
+                    thread,
+                    msg,
+                    location.file(),
+                    location.line(),
+                    backtrace
+                )
+            }
+            None => {
+                format!(
+                    "\nthread '{}' panicked at '{}'\n{:?}",
+                    thread, msg, backtrace
+                )
+            }
+        };
+
+        if send_app_instructions_clone
+            .send(AppInstruction::Error(backtrace.clone()))
+            .is_err()
+        {
+            get_os_input().unset_raw_mode(0);
+            println!("{}", backtrace);
+        }
+    }));
 
     active_threads.push(
         thread::Builder::new()
@@ -408,8 +412,6 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: Opt) {
             use std::io::Read;
             let send_pty_instructions = send_pty_instructions.clone();
             let send_screen_instructions = send_screen_instructions.clone();
-            let send_app_instructions = send_app_instructions.clone();
-            let mut os_input = os_input.clone();
             move || {
                 std::fs::remove_file(MOSAIC_IPC_PIPE).ok();
                 let listener = std::os::unix::net::UnixListener::bind(MOSAIC_IPC_PIPE)
@@ -445,11 +447,6 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: Opt) {
                                     send_screen_instructions
                                         .send(ScreenInstruction::MoveFocus)
                                         .unwrap();
-                                }
-                                ApiCommand::Error(backtrace) => {
-                                    os_input.unset_raw_mode(0);
-                                    println!("{}", backtrace);
-                                    send_app_instructions.send(AppInstruction::Error).unwrap();
                                 }
                             }
                         }
@@ -491,7 +488,9 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: Opt) {
                 let _ = send_pty_instructions.send(PtyInstruction::Quit);
                 break;
             }
-            AppInstruction::Error => {
+            AppInstruction::Error(backtrace) => {
+                os_input.unset_raw_mode(0);
+                println!("{}", backtrace);
                 let _ = send_screen_instructions.send(ScreenInstruction::Quit);
                 let _ = send_pty_instructions.send(PtyInstruction::Quit);
                 for thread_handler in active_threads {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::io::Write;
 use std::os::unix::io::RawFd;
-use std::sync::mpsc::{Receiver, Sender};
+use std::sync::mpsc::{Receiver, Sender, SyncSender};
 
 use crate::boundaries::Boundaries;
 use crate::layout::Layout;
@@ -75,7 +75,7 @@ pub struct Screen {
     pub receiver: Receiver<ScreenInstruction>,
     max_panes: Option<usize>,
     send_pty_instructions: Sender<PtyInstruction>,
-    send_app_instructions: Sender<AppInstruction>,
+    send_app_instructions: SyncSender<AppInstruction>,
     full_screen_ws: PositionAndSize,
     terminals: BTreeMap<RawFd, TerminalPane>, // BTreeMap because we need a predictable order when changing focus
     panes_to_hide: HashSet<RawFd>,
@@ -88,7 +88,7 @@ impl Screen {
     pub fn new(
         receive_screen_instructions: Receiver<ScreenInstruction>,
         send_pty_instructions: Sender<PtyInstruction>,
-        send_app_instructions: Sender<AppInstruction>,
+        send_app_instructions: SyncSender<AppInstruction>,
         full_screen_ws: &PositionAndSize,
         os_api: Box<dyn OsApi>,
         max_panes: Option<usize>,

--- a/src/terminal_pane/scroll.rs
+++ b/src/terminal_pane/scroll.rs
@@ -1,5 +1,5 @@
-use ::std::collections::VecDeque;
-use ::std::fmt::{self, Debug, Formatter};
+use std::collections::VecDeque;
+use std::fmt::{self, Debug, Formatter};
 
 use crate::terminal_pane::terminal_character::{
     CharacterStyles, TerminalCharacter, EMPTY_TERMINAL_CHARACTER,

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -12,7 +12,7 @@ use crate::tests::possible_tty_inputs::{get_possible_tty_inputs, Bytes};
 use crate::tests::utils::commands::QUIT;
 
 const MIN_TIME_BETWEEN_SNAPSHOTS: Duration = Duration::from_millis(50);
-const WAIT_TIME_BEFORE_QUITTING: Duration = Duration::from_millis(100);
+const WAIT_TIME_BEFORE_QUITTING: Duration = Duration::from_millis(50);
 
 #[derive(Clone)]
 pub enum IoEvent {

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -12,7 +12,7 @@ use crate::tests::possible_tty_inputs::{get_possible_tty_inputs, Bytes};
 use crate::tests::utils::commands::QUIT;
 
 const MIN_TIME_BETWEEN_SNAPSHOTS: Duration = Duration::from_millis(50);
-const WAIT_TIME_BEFORE_QUITTING: Duration = Duration::from_millis(500);
+const WAIT_TIME_BEFORE_QUITTING: Duration = Duration::from_millis(100);
 
 #[derive(Clone)]
 pub enum IoEvent {

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -214,7 +214,7 @@ impl OsApi for FakeInputOutput {
                     std::thread::sleep(WAIT_TIME_BEFORE_QUITTING);
                 }
                 command
-            },
+            }
             None => {
                 // what is happening here?
                 //

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use crate::os_input_output::OsApi;
 use crate::tests::possible_tty_inputs::{get_possible_tty_inputs, Bytes};
 
-const MIN_TIME_BETWEEN_SNAPSHOTS: Duration = Duration::from_millis(50);
+const MIN_TIME_BETWEEN_SNAPSHOTS: Duration = Duration::from_millis(500);
 
 #[derive(Clone)]
 pub enum IoEvent {

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -1,11 +1,11 @@
 use crate::terminal_pane::PositionAndSize;
-use ::std::collections::{HashMap, VecDeque};
-use ::std::io::Write;
-use ::std::os::unix::io::RawFd;
-use ::std::path::PathBuf;
-use ::std::sync::atomic::{AtomicBool, Ordering};
-use ::std::sync::{Arc, Mutex};
-use ::std::time::{Duration, Instant};
+use std::collections::{HashMap, VecDeque};
+use std::io::Write;
+use std::os::unix::io::RawFd;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use crate::os_input_output::OsApi;
 use crate::tests::possible_tty_inputs::{get_possible_tty_inputs, Bytes};

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -10,7 +10,8 @@ use std::time::{Duration, Instant};
 use crate::os_input_output::OsApi;
 use crate::tests::possible_tty_inputs::{get_possible_tty_inputs, Bytes};
 
-const MIN_TIME_BETWEEN_SNAPSHOTS: Duration = Duration::from_millis(500);
+const MIN_TIME_BETWEEN_SNAPSHOTS: Duration = Duration::from_millis(50);
+const WAIT_TIME_BEFORE_QUITTING: Duration = Duration::from_millis(500);
 
 #[derive(Clone)]
 pub enum IoEvent {
@@ -207,7 +208,12 @@ impl OsApi for FakeInputOutput {
             }
         }
         match self.stdin_commands.lock().unwrap().pop_front() {
-            Some(command) => command,
+            Some(command) => {
+                if command == QUIT {
+                    std::thread::sleep(WAIT_TIME_BEFORE_QUITTING);
+                }
+                command
+            },
             None => {
                 // what is happening here?
                 //

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use crate::os_input_output::OsApi;
 use crate::tests::possible_tty_inputs::{get_possible_tty_inputs, Bytes};
+use crate::tests::utils::commands::QUIT;
 
 const MIN_TIME_BETWEEN_SNAPSHOTS: Duration = Duration::from_millis(50);
 const WAIT_TIME_BEFORE_QUITTING: Duration = Duration::from_millis(500);

--- a/src/tests/integration/layouts.rs
+++ b/src/tests/integration/layouts.rs
@@ -1,4 +1,4 @@
-use ::insta::assert_snapshot;
+use insta::assert_snapshot;
 use std::path::PathBuf;
 
 use crate::terminal_pane::PositionAndSize;

--- a/src/tests/integration/resize_down.rs
+++ b/src/tests/integration/resize_down.rs
@@ -1,4 +1,4 @@
-use ::insta::assert_snapshot;
+use insta::assert_snapshot;
 
 use crate::terminal_pane::PositionAndSize;
 use crate::tests::fakes::FakeInputOutput;


### PR DESCRIPTION
feat: print backtrace on panic and ensure proper shutdown.

The implementation works as follows- a custom panic hook collects the backtrace, sends it over to the ipc_thread via socket. The ipc_thread unsets `raw_mode` and prints the backtrace and sends a message to the main thread which joins the active threads and exits.

`Sender<AppInstruction>` does not implement `Sync` and thus could not be captured by the closure in `panic::set_hook()`. We, therefore, have to go through `ipc_thread` for signalling the main thread.