### PR TITLE
Fix a race condition, build-times, and warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,21 @@ bincode = "1.3.1"
 structopt = "0.3"
 serde_yaml = "0.8"
 serde_json = "1.0"
-wasmer = { git = "https://github.com/wasmerio/wasmer.git" }
-wasmer-wasi = { git = "https://github.com/wasmerio/wasmer.git" }
 
 [dependencies.async-std]
 version = "1.3.0"
 features = ["unstable"]
+
+[dependencies.wasmer]
+git = "https://github.com/wasmerio/wasmer.git"
+optional = true
+
+[dependencies.wasmer-wasi]
+git = "https://github.com/wasmerio/wasmer.git"
+optional = true
+
+[features]
+wasm-wip = ["wasmer", "wasmer-wasi"]
 
 [dev-dependencies]
 insta = "0.16.1"

--- a/src/pty_bus.rs
+++ b/src/pty_bus.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use crate::layout::Layout;
 use crate::os_input_output::OsApi;
-use crate::utils::logging::{debug_log_to_file, debug_to_file};
+use crate::utils::logging::debug_to_file;
 use crate::ScreenInstruction;
 
 pub struct ReadFromPid {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -380,7 +380,7 @@ impl Screen {
         }
     }
     pub fn handle_pty_event(&mut self, pid: RawFd, event: VteEvent) {
-        if let Some(terminal_output) = self.terminals.get_mut(&pid){
+        if let Some(terminal_output) = self.terminals.get_mut(&pid) {
             terminal_output.handle_event(event);
         }
     }

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -380,6 +380,11 @@ impl Screen {
         }
     }
     pub fn handle_pty_event(&mut self, pid: RawFd, event: VteEvent) {
+        // if we don't have the terminal in self.terminals it's probably because
+        // of a race condition where the terminal was created in pty_bus but has not
+        // yet been created in Screen. These events are currently not buffered, so
+        // if you're debugging seemingly randomly missing stdout data, this is
+        // the reason
         if let Some(terminal_output) = self.terminals.get_mut(&pid) {
             terminal_output.handle_event(event);
         }

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -380,8 +380,9 @@ impl Screen {
         }
     }
     pub fn handle_pty_event(&mut self, pid: RawFd, event: VteEvent) {
-        let terminal_output = self.terminals.get_mut(&pid).unwrap();
-        terminal_output.handle_event(event);
+        if let Some(terminal_output) = self.terminals.get_mut(&pid){
+            terminal_output.handle_event(event);
+        }
     }
     pub fn write_to_active_terminal(&mut self, mut bytes: Vec<u8>) {
         if let Some(active_terminal_id) = &self.get_active_terminal_id() {

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -23,14 +23,9 @@ pub fn atomic_create_dir(dir_name: &str) -> io::Result<()> {
     }
 }
 
-pub fn debug_log_to_file(message: String) -> io::Result<()> {
-    atomic_create_file(MOSAIC_TMP_LOG_FILE);
-    let mut file = fs::OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(MOSAIC_TMP_LOG_FILE)?;
-    file.write_all(message.as_bytes())?;
-    file.write_all(b"\n")
+pub fn debug_log_to_file(mut message: String) -> io::Result<()> {
+    message.push('\n');
+    debug_log_to_file_without_newline(message)
 }
 
 pub fn debug_log_to_file_without_newline(message: String) -> io::Result<()> {
@@ -39,9 +34,7 @@ pub fn debug_log_to_file_without_newline(message: String) -> io::Result<()> {
         .append(true)
         .create(true)
         .open(MOSAIC_TMP_LOG_FILE)?;
-    file.write_all(message.as_bytes())?;
-
-    Ok(())
+    file.write_all(message.as_bytes())
 }
 
 pub fn debug_log_to_file_pid_0(message: String, pid: RawFd) -> io::Result<()> {


### PR DESCRIPTION
This is a bit a variety PR, but it brings build times down from 53 to 23 seconds (less than half the time) and gets rid of nearly all of the compiler warnings.

Oh, also fixes a race condition with pty_bus and layouts!