### PR TITLE
fix(compatibility): keypad arrow fixes

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -383,10 +383,12 @@ impl Screen {
         let terminal_output = self.terminals.get_mut(&pid).unwrap();
         terminal_output.handle_event(event);
     }
-    pub fn write_to_active_terminal(&mut self, mut bytes: Vec<u8>) {
+    pub fn write_to_active_terminal(&mut self, input_bytes: Vec<u8>) {
         if let Some(active_terminal_id) = &self.get_active_terminal_id() {
+            let active_terminal = self.get_active_terminal().unwrap();
+            let mut adjusted_input = active_terminal.adjust_input_to_terminal(input_bytes);
             self.os_api
-                .write_to_tty_stdin(*active_terminal_id, &mut bytes)
+                .write_to_tty_stdin(*active_terminal_id, &mut adjusted_input)
                 .expect("failed to write to terminal");
             self.os_api
                 .tcdrain(*active_terminal_id)

--- a/src/terminal_pane/terminal_pane.rs
+++ b/src/terminal_pane/terminal_pane.rs
@@ -38,6 +38,7 @@ pub struct TerminalPane {
     pub should_render: bool,
     pub position_and_size: PositionAndSize,
     pub position_and_size_override: Option<PositionAndSize>,
+    pub cursor_key_mode: bool, // DECCKM - when set, cursor keys should send ANSI direction codes (eg. "OD") instead of the arrow keys (eg. "[D")
     pending_styles: CharacterStyles,
 }
 
@@ -73,6 +74,7 @@ impl TerminalPane {
             pending_styles,
             position_and_size,
             position_and_size_override: None,
+            cursor_key_mode: false,
         }
     }
     pub fn mark_for_rerender(&mut self) {
@@ -275,6 +277,36 @@ impl TerminalPane {
         self.position_and_size_override = None;
         self.reflow_lines();
         self.mark_for_rerender();
+    }
+    pub fn adjust_input_to_terminal(&self, input_bytes: Vec<u8>) -> Vec<u8> {
+        // there are some cases in which the terminal state means that input sent to it
+        // needs to be adjusted.
+        // here we match against those cases - if need be, we adjust the input and if not
+        // we send back the original input
+        match input_bytes.as_slice() {
+            [27, 91, 68] => { // left arrow
+                if self.cursor_key_mode { 
+                    return "OD".as_bytes().to_vec()
+                }
+            },
+            [27, 91, 67] => { // right arrow
+                if self.cursor_key_mode {
+                    return "OC".as_bytes().to_vec()
+                }
+            },
+            [27, 91, 65] => { // up arrow
+                if self.cursor_key_mode {
+                    return "OA".as_bytes().to_vec()
+                }
+            },
+            [27, 91, 66] => { // down arrow
+                if self.cursor_key_mode {
+                    return "OB".as_bytes().to_vec()
+                }
+            }
+            _ => {}
+        };
+        input_bytes
     }
     fn add_newline(&mut self) {
         self.scroll.add_canonical_line();
@@ -728,9 +760,15 @@ impl vte::Perform for TerminalPane {
                 _ => false,
             };
             if first_intermediate_is_questionmark {
-                if let Some(&25) = params.get(0) {
-                    self.scroll.hide_cursor();
-                    self.mark_for_rerender();
+                match params.get(0) {
+                    Some(&25) => {
+                        self.scroll.hide_cursor();
+                        self.mark_for_rerender();
+                    },
+                    Some(&1) => {
+                        self.cursor_key_mode = false;
+                    }
+                    _ => {}
                 };
             }
         } else if c == 'h' {
@@ -740,9 +778,15 @@ impl vte::Perform for TerminalPane {
                 _ => false,
             };
             if first_intermediate_is_questionmark {
-                if let Some(&25) = params.get(0) {
-                    self.scroll.show_cursor();
-                    self.mark_for_rerender();
+                match params.get(0) {
+                    Some(&25) => {
+                        self.scroll.show_cursor();
+                        self.mark_for_rerender();
+                    },
+                    Some(&1) => {
+                        self.cursor_key_mode = true;
+                    }
+                    _ => {}
                 };
             }
         } else if c == 'r' {
@@ -838,12 +882,7 @@ impl vte::Perform for TerminalPane {
             (b'M', None) => {
                 self.scroll.move_cursor_up_in_scroll_region(1);
             }
-            _ => {
-                let _ = debug_log_to_file(format!(
-                    "Unhandled esc_dispatch: {}->{:?}",
-                    byte, intermediates
-                ));
-            }
+            _ => {}
         }
     }
 }

--- a/src/terminal_pane/terminal_pane.rs
+++ b/src/terminal_pane/terminal_pane.rs
@@ -284,32 +284,36 @@ impl TerminalPane {
         // here we match against those cases - if need be, we adjust the input and if not
         // we send back the original input
         match input_bytes.as_slice() {
-            [27, 91, 68] => { // left arrow
-                if self.cursor_key_mode { 
-                    // please note that in the line below, there is an ANSI escape code (27) at the beginning of the string,
-                    // some editors will not show this
-                    return "OD".as_bytes().to_vec()
-                }
-            },
-            [27, 91, 67] => { // right arrow
+            [27, 91, 68] => {
+                // left arrow
                 if self.cursor_key_mode {
                     // please note that in the line below, there is an ANSI escape code (27) at the beginning of the string,
                     // some editors will not show this
-                    return "OC".as_bytes().to_vec()
+                    return "OD".as_bytes().to_vec();
                 }
-            },
-            [27, 91, 65] => { // up arrow
+            }
+            [27, 91, 67] => {
+                // right arrow
                 if self.cursor_key_mode {
                     // please note that in the line below, there is an ANSI escape code (27) at the beginning of the string,
                     // some editors will not show this
-                    return "OA".as_bytes().to_vec()
+                    return "OC".as_bytes().to_vec();
                 }
-            },
-            [27, 91, 66] => { // down arrow
+            }
+            [27, 91, 65] => {
+                // up arrow
                 if self.cursor_key_mode {
                     // please note that in the line below, there is an ANSI escape code (27) at the beginning of the string,
                     // some editors will not show this
-                    return "OB".as_bytes().to_vec()
+                    return "OA".as_bytes().to_vec();
+                }
+            }
+            [27, 91, 66] => {
+                // down arrow
+                if self.cursor_key_mode {
+                    // please note that in the line below, there is an ANSI escape code (27) at the beginning of the string,
+                    // some editors will not show this
+                    return "OB".as_bytes().to_vec();
                 }
             }
             _ => {}
@@ -772,7 +776,7 @@ impl vte::Perform for TerminalPane {
                     Some(&25) => {
                         self.scroll.hide_cursor();
                         self.mark_for_rerender();
-                    },
+                    }
                     Some(&1) => {
                         self.cursor_key_mode = false;
                     }
@@ -790,7 +794,7 @@ impl vte::Perform for TerminalPane {
                     Some(&25) => {
                         self.scroll.show_cursor();
                         self.mark_for_rerender();
-                    },
+                    }
                     Some(&1) => {
                         self.cursor_key_mode = true;
                     }

--- a/src/terminal_pane/terminal_pane.rs
+++ b/src/terminal_pane/terminal_pane.rs
@@ -286,21 +286,29 @@ impl TerminalPane {
         match input_bytes.as_slice() {
             [27, 91, 68] => { // left arrow
                 if self.cursor_key_mode { 
+                    // please note that in the line below, there is an ANSI escape code (27) at the beginning of the string,
+                    // some editors will not show this
                     return "OD".as_bytes().to_vec()
                 }
             },
             [27, 91, 67] => { // right arrow
                 if self.cursor_key_mode {
+                    // please note that in the line below, there is an ANSI escape code (27) at the beginning of the string,
+                    // some editors will not show this
                     return "OC".as_bytes().to_vec()
                 }
             },
             [27, 91, 65] => { // up arrow
                 if self.cursor_key_mode {
+                    // please note that in the line below, there is an ANSI escape code (27) at the beginning of the string,
+                    // some editors will not show this
                     return "OA".as_bytes().to_vec()
                 }
             },
             [27, 91, 66] => { // down arrow
                 if self.cursor_key_mode {
+                    // please note that in the line below, there is an ANSI escape code (27) at the beginning of the string,
+                    // some editors will not show this
                     return "OB".as_bytes().to_vec()
                 }
             }


### PR DESCRIPTION
This fix adds support for "keyboard transmit". The terminal event `DECCKM` switches it on and off. This essentially means that the arrow keys should transmit their ansi movement codes instead of the arrow key codes themselves.

Some terminals support this and some do not, as indicated *I think* by their terminfo. This is read by the application running inside the terminal, which then decides whether to send this event or not. So we just need to react to the event and transmit the proper codes accordingly - which is what this PR does.

For more information: https://vt100.net/docs/vt100-ug/chapter3.html#T3-6