### PR TITLE
fix(compatibility): do not offset first scroll region line

### DIFF
--- a/src/terminal_pane/scroll.rs
+++ b/src/terminal_pane/scroll.rs
@@ -641,12 +641,9 @@ impl Scroll {
     }
     pub fn delete_lines_in_scroll_region(&mut self, count: usize) {
         if let Some((scroll_region_top, scroll_region_bottom)) = self.scroll_region {
-            // the scroll region indices start at 1, so we need to adjust them
-            let scroll_region_top_index = scroll_region_top - 1;
-            let scroll_region_bottom_index = scroll_region_bottom - 1;
             let current_canonical_line_index = self.cursor_position.line_index.0;
-            if current_canonical_line_index >= scroll_region_top_index
-                && current_canonical_line_index <= scroll_region_bottom_index
+            if current_canonical_line_index >= scroll_region_top
+                && current_canonical_line_index <= scroll_region_bottom
             {
                 // when deleting lines inside the scroll region, we must make sure it stays the
                 // same size (and that other lines below it aren't shifted inside it)
@@ -655,26 +652,23 @@ impl Scroll {
                 for _ in 0..count {
                     self.canonical_lines.remove(current_canonical_line_index);
                     self.canonical_lines
-                        .insert(scroll_region_bottom_index + 1, CanonicalLine::new());
+                        .insert(scroll_region_bottom, CanonicalLine::new());
                 }
             }
         }
     }
     pub fn add_empty_lines_in_scroll_region(&mut self, count: usize) {
         if let Some((scroll_region_top, scroll_region_bottom)) = self.scroll_region {
-            // the scroll region indices start at 1, so we need to adjust them
-            let scroll_region_top_index = scroll_region_top - 1;
-            let scroll_region_bottom_index = scroll_region_bottom - 1;
             let current_canonical_line_index = self.cursor_position.line_index.0;
-            if current_canonical_line_index >= scroll_region_top_index
-                && current_canonical_line_index <= scroll_region_bottom_index
+            if current_canonical_line_index >= scroll_region_top
+                && current_canonical_line_index <= scroll_region_bottom
             {
                 // when adding empty lines inside the scroll region, we must make sure it stays the
                 // same size and that lines don't "leak" outside of it
                 // so we add an empty line where the cursor currently is, and delete the last line
                 // of the scroll region
                 for _ in 0..count {
-                    self.canonical_lines.remove(scroll_region_bottom_index + 1);
+                    self.canonical_lines.remove(scroll_region_bottom);
                     self.canonical_lines
                         .insert(current_canonical_line_index, CanonicalLine::new());
                 }

--- a/src/tests/integration/snapshots/mosaic__tests__integration__compatibility__htop_scrolling.snap
+++ b/src/tests/integration/snapshots/mosaic__tests__integration__compatibility__htop_scrolling.snap
@@ -2,6 +2,7 @@
 source: src/tests/integration/compatibility.rs
 expression: snapshot
 ---
+█                                                                                                                   
   1  [||||||||||||||||||||||||||||||||||||||||||100.0%]   Tasks: 79, 382 thr; 1 running                             
   2  [                                            0.0%]   Load average: 1.40 1.43 1.38                              
   3  [                                            0.0%]   Uptime: 2 days, 07:33:50                                  
@@ -29,4 +30,3 @@ expression: snapshot
     444 root       20   0 1635M 83324 44976 S  0.0  0.5  0:33.13 /usr/bin/dockerd -H fd://                          
     449 root       20   0 1635M 83324 44976 S  0.0  0.5  0:41.39 /usr/bin/dockerd -H fd://                          
 F1Help  F2Setup F3SearchF4FilterF5Tree  F6SortByF7Nice -F8Nice +F9Kill  F10Quit                                     
-█                                                                                                                   

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -37,8 +37,8 @@ pub fn debug_log_to_file_without_newline(message: String) -> io::Result<()> {
     file.write_all(message.as_bytes())
 }
 
-pub fn debug_log_to_file_pid_0(message: String, pid: RawFd) -> io::Result<()> {
-    if pid == 0 {
+pub fn debug_log_to_file_pid_3(message: String, pid: RawFd) -> io::Result<()> {
+    if pid == 3 {
         debug_log_to_file(message)
     } else {
         Ok(())


### PR DESCRIPTION
This fixes a bug where when we had a scroll region (eg. in vim, htop, etc.) the first line was offset by 1 in certain cases.