### PR TITLE
fix(compatibility): fix neovim scrolling

### DIFF
--- a/src/terminal_pane/terminal_pane.rs
+++ b/src/terminal_pane/terminal_pane.rs
@@ -473,7 +473,8 @@ impl vte::Perform for TerminalPane {
             if first_intermediate_is_questionmark {
                 match params.get(0) {
                     Some(&1049) => {
-                        self.scroll.override_current_buffer_with_alternative_buffer();
+                        self.scroll
+                            .override_current_buffer_with_alternative_buffer();
                     }
                     Some(&25) => {
                         self.scroll.hide_cursor();

--- a/src/terminal_pane/terminal_pane.rs
+++ b/src/terminal_pane/terminal_pane.rs
@@ -452,15 +452,6 @@ impl vte::Perform for TerminalPane {
                     (params[0] as usize - 1, params[1] as usize - 1)
                 }
             };
-            if params.len() >= 1 && params[0] == 0 {
-                // this is a hack
-                //
-                // the logic should *probably* be:
-                // if we get an instruction to move outside the scroll region
-                // (which is 1 indexed, so if we get 0 it's always(?) outside)
-                // we need to set it to screen size
-                self.scroll.set_scroll_region_to_screen_size();
-            }
             self.scroll.move_cursor_to(row, col);
         } else if c == 'A' {
             // move cursor up until edge of screen
@@ -481,6 +472,9 @@ impl vte::Perform for TerminalPane {
             };
             if first_intermediate_is_questionmark {
                 match params.get(0) {
+                    Some(&1049) => {
+                        self.scroll.override_current_buffer_with_alternative_buffer();
+                    }
                     Some(&25) => {
                         self.scroll.hide_cursor();
                         self.mark_for_rerender();
@@ -502,6 +496,9 @@ impl vte::Perform for TerminalPane {
                     Some(&25) => {
                         self.scroll.show_cursor();
                         self.mark_for_rerender();
+                    }
+                    Some(&1049) => {
+                        self.scroll.move_current_buffer_to_alternative_buffer();
                     }
                     Some(&1) => {
                         self.cursor_key_mode = true;


### PR DESCRIPTION
This fixes an issue where neovim did not scroll up/down properly (it deleted the whole screen).

This happened because we previously treated clearing the scroll region as deleting all of it (in order to re-create the vim/htop/etc. behaviour of returning to the previous terminal state when exiting the app). This apparently happens in a different signal (mode setting with CSI l/h). Moved it there and it fixed this bug (as well as keeping the behaviour of clearing the terminal buffer when exiting vim/htop).