### PR TITLE
fix(compatibility): don't drop empty lines when resizing

### DIFF
--- a/src/panes/grid.rs
+++ b/src/panes/grid.rs
@@ -272,6 +272,9 @@ impl Grid {
             let mut new_viewport_rows = vec![];
             for mut canonical_line in viewport_canonical_lines {
                 let mut canonical_line_parts: Vec<Row> = vec![];
+                if canonical_line.columns.is_empty() {
+                    canonical_line_parts.push(Row::new().canonical());
+                }
                 while !canonical_line.columns.is_empty() {
                     let next_wrap = if canonical_line.len() > new_columns {
                         canonical_line.columns.drain(..new_columns)
@@ -279,7 +282,7 @@ impl Grid {
                         canonical_line.columns.drain(..)
                     };
                     let row = Row::from_columns(next_wrap.collect());
-                    // if there are no more parts, this row is canonical as long as it originall
+                    // if there are no more parts, this row is canonical as long as it originally
                     // was canonical (it might not have been for example if it's the first row in
                     // the viewport, and the actual canonical row is above it in the scrollback)
                     let row = if canonical_line_parts.is_empty() && canonical_line.is_canonical {

--- a/src/panes/terminal_pane.rs
+++ b/src/panes/terminal_pane.rs
@@ -496,6 +496,7 @@ impl vte::Perform for TerminalPane {
                             std::mem::swap(&mut self.grid, alternative_grid);
                         }
                         self.alternative_grid = None;
+                        self.mark_for_rerender();
                     }
                     Some(&25) => {
                         self.grid.hide_cursor();


### PR DESCRIPTION
This fixes the second half of: https://github.com/mosaic-org/mosaic/issues/139

Namely:
Entering neovim, increasing the size of the pane to the left and then exiting.
The issue was that when we resized the alternative grid (the one we stored once we entered neovim) we were dropping an empty line, so when we came back, the cursor overrode it and so a part of it was still left that the cursor did not delete.