### PR TITLE
fix(compatibility): fix grid glitch edge-case when resizing

### DIFF
--- a/src/panes/grid.rs
+++ b/src/panes/grid.rs
@@ -636,7 +636,7 @@ impl Grid {
                 // region
                 for _ in 0..count {
                     self.viewport.remove(current_line_index);
-                    self.viewport.insert(scroll_region_bottom, Row::new());
+                    self.viewport.insert(scroll_region_bottom, Row::new().canonical());
                 }
             }
         }
@@ -652,7 +652,7 @@ impl Grid {
                 // of the scroll region
                 for _ in 0..count {
                     self.viewport.remove(scroll_region_bottom);
-                    self.viewport.insert(current_line_index, Row::new());
+                    self.viewport.insert(current_line_index, Row::new().canonical());
                 }
             }
         }

--- a/src/panes/grid.rs
+++ b/src/panes/grid.rs
@@ -636,7 +636,8 @@ impl Grid {
                 // region
                 for _ in 0..count {
                     self.viewport.remove(current_line_index);
-                    self.viewport.insert(scroll_region_bottom, Row::new().canonical());
+                    self.viewport
+                        .insert(scroll_region_bottom, Row::new().canonical());
                 }
             }
         }
@@ -652,7 +653,8 @@ impl Grid {
                 // of the scroll region
                 for _ in 0..count {
                     self.viewport.remove(scroll_region_bottom);
-                    self.viewport.insert(current_line_index, Row::new().canonical());
+                    self.viewport
+                        .insert(current_line_index, Row::new().canonical());
                 }
             }
         }


### PR DESCRIPTION
This bug happened when we resized a pane with a scrolling region (eg. vim) in certain edge cases.
It happened because we were adding a linewrap instead of a line when when scrolling inside of a scroll region. This created a cascade that messed up the state and caused problems. No longer!