### PR TITLE
feat(metadata): Add metadata to Cargo.toml for building deb packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,13 @@ structopt = "0.3"
 lto = true
 
 [package.metadata.deb]
+depends = "$auto"
+license-file = ["LICENSE.md", "4"]
 assets = [
   # TODO?
   # ["assets/man/mosaic.1", "usr/share/man/man1/mosaic.1", "644"],
   ["target/release/mosaic", "usr/bin/mosaic", "755"],
-  ["LICENSE.md", "usr/share/doc/mosaic/", "644"],
-  ["GOVERNANCE.md", "usr/share/doc/mosaic/", "644"],
+  ["GOVERNANCE.md", "usr/share/doc/mosaic/GOVERNANCE.md", "644"],
   ["README.md", "usr/share/doc/mosaic/README", "644"],
   ["assets/layouts/*", "/usr/share/mosaic/layouts/", "644"],
   ["assets/plugins/*", "/usr/share/mosaic/plugins/", "644"],

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,18 @@ structopt = "0.3"
 
 [profile.release]
 lto = true
+
+[package.metadata.deb]
+assets = [
+  # TODO?
+  # ["assets/man/mosaic.1", "usr/share/man/man1/mosaic.1", "644"],
+  ["target/release/mosaic", "usr/bin/mosaic", "755"],
+  ["LICENSE.md", "usr/share/doc/mosaic/", "644"],
+  ["GOVERNANCE.md", "usr/share/doc/mosaic/", "644"],
+  ["README.md", "usr/share/doc/mosaic/README", "644"],
+  ["assets/layouts/*", "/usr/share/mosaic/layouts/", "644"],
+  ["assets/plugins/*", "/usr/share/mosaic/plugins/", "644"],
+  ["assets/completions/mosaic.bash", "usr/share/bash-completion/completions/mosaic.bash", "644"],
+  ["assets/completions/mosaic.fish", "usr/share/fish/vendor_completions.d/mosaic.fish", "644"],
+  ["assets/completions/_mosaic", "usr/share/zsh/vendor-completions/_mosaic", "644"],
+]


### PR DESCRIPTION
Add metadata to `Cargo.toml`, which is required by `cargo-deb` to build the deb package.