### PR TITLE
fix(compatibility): properly erase previous state before switching grids

### DIFF
--- a/src/panes/grid.rs
+++ b/src/panes/grid.rs
@@ -143,8 +143,8 @@ pub struct Grid {
     lines_below: Vec<Row>,
     cursor: Cursor,
     scroll_region: Option<(usize, usize)>,
-    width: usize,
-    height: usize,
+    pub width: usize,
+    pub height: usize,
 }
 
 impl Debug for Grid {

--- a/src/panes/terminal_pane.rs
+++ b/src/panes/terminal_pane.rs
@@ -192,7 +192,12 @@ impl Pane for TerminalPane {
                 for line_index in 0..self.grid.height {
                     let x = self.get_x();
                     let y = self.get_y();
-                    vte_output = format!("{}\u{1b}[{};{}H\u{1b}[m", vte_output, y + line_index + 1, x + 1); // goto row/col and reset styles
+                    vte_output = format!(
+                        "{}\u{1b}[{};{}H\u{1b}[m",
+                        vte_output,
+                        y + line_index + 1,
+                        x + 1
+                    ); // goto row/col and reset styles
                     for _col_index in 0..self.grid.width {
                         vte_output.push(EMPTY_TERMINAL_CHARACTER.character);
                     }

--- a/src/panes/terminal_pane.rs
+++ b/src/panes/terminal_pane.rs
@@ -47,6 +47,7 @@ pub struct TerminalPane {
     pub position_and_size_override: Option<PositionAndSize>,
     pub cursor_key_mode: bool, // DECCKM - when set, cursor keys should send ANSI direction codes (eg. "OD") instead of the arrow keys (eg. "[D")
     pending_styles: CharacterStyles,
+    clear_viewport_before_rendering: bool,
 }
 
 impl Pane for TerminalPane {
@@ -187,6 +188,17 @@ impl Pane for TerminalPane {
             let buffer_lines = &self.read_buffer_as_lines();
             let display_cols = self.get_columns();
             let mut character_styles = CharacterStyles::new();
+            if self.clear_viewport_before_rendering {
+                for line_index in 0..self.grid.height {
+                    let x = self.get_x();
+                    let y = self.get_y();
+                    vte_output = format!("{}\u{1b}[{};{}H\u{1b}[m", vte_output, y + line_index + 1, x + 1); // goto row/col and reset styles
+                    for _col_index in 0..self.grid.width {
+                        vte_output.push(EMPTY_TERMINAL_CHARACTER.character);
+                    }
+                }
+                self.clear_viewport_before_rendering = false;
+            }
             for (row, line) in buffer_lines.iter().enumerate() {
                 let x = self.get_x();
                 let y = self.get_y();
@@ -291,6 +303,7 @@ impl TerminalPane {
             position_and_size,
             position_and_size_override: None,
             cursor_key_mode: false,
+            clear_viewport_before_rendering: false,
         }
     }
     pub fn mark_for_rerender(&mut self) {
@@ -496,6 +509,7 @@ impl vte::Perform for TerminalPane {
                             std::mem::swap(&mut self.grid, alternative_grid);
                         }
                         self.alternative_grid = None;
+                        self.clear_viewport_before_rendering = true;
                         self.mark_for_rerender();
                     }
                     Some(&25) => {
@@ -532,6 +546,7 @@ impl vte::Perform for TerminalPane {
                         let current_grid =
                             std::mem::replace(&mut self.grid, Grid::new(rows, columns));
                         self.alternative_grid = Some(current_grid);
+                        self.clear_viewport_before_rendering = true;
                     }
                     Some(&1) => {
                         self.cursor_key_mode = true;


### PR DESCRIPTION
This is an additional fix for: https://github.com/mosaic-org/mosaic/issues/115
The issue was as follows:
When vim/nvim is opened, it switches the terminal display to a new buffer. When it exits, it tells the terminal emulator to restore the display to the previous buffer. This issue happened when the previous buffer had tab characters.
What was happening is that we were forwarding the tab character to the terminal emulator, who then skipped to the next tab stop in the line, not clearing the styles beneath it (from the previous buffer we just cleared). And that's why we had some leftover styles from the buffer.
To fix this, I introduced a `clear_viewport_before_rendering` flag to the terminal pane, to be set when we switch buffers (grids for us). When that flag is set, the render function clears the entire buffer before rendering what is in the terminal, thus removing all previous styles before introducing new ones.

Good catch, @henil !